### PR TITLE
Added RPC registrar to core

### DIFF
--- a/packages/core/src/app/common/net/rpc/index.ts
+++ b/packages/core/src/app/common/net/rpc/index.ts
@@ -1,1 +1,2 @@
 export * from './json-rpc'
+export * from './utils'

--- a/packages/core/src/app/common/net/rpc/utils.ts
+++ b/packages/core/src/app/common/net/rpc/utils.ts
@@ -1,0 +1,24 @@
+/* Internal Imports */
+import { RpcServer, FunctionPropertyNames } from '../../../../interfaces'
+import { autobind } from '../../utils'
+
+/**
+ * Registers methods to an RPC server by
+ * binding them to a given object.
+ * Gets around annoying `x.fn.bind(x)` calls.
+ * @param rpc Server to register to.
+ * @param obj Object to bind to.
+ * @param fns Names of the functions to bind.
+ */
+export const registerBound = <T>(
+  rpc: RpcServer,
+  obj: T,
+  fns: Array<FunctionPropertyNames<T>>
+): void => {
+  const methods = autobind(obj, fns)
+
+  for (const name of Object.keys(methods)) {
+    const method = methods[name]
+    rpc.register(name, method)
+  }
+}

--- a/packages/core/src/app/common/utils/misc.ts
+++ b/packages/core/src/app/common/utils/misc.ts
@@ -1,6 +1,9 @@
 /* External Imports */
 import BigNum = require('bn.js')
 
+/* Internal Imports */
+import { FunctionPropertyNames, OneOrMore } from '../../../interfaces'
+
 /**
  * JSON-stringifies a value if it's not already a string.
  * @param value Value to stringify.
@@ -74,4 +77,28 @@ export const prettify = (obj: PrettyPrintable): string => {
       : value
   }
   return JSON.stringify(parsed, null, 2)
+}
+
+/**
+ * Binds a function or list of functions to
+ * an object. Gets around the annoying
+ * `x.fn.bind(x)` syntax. If several functions
+ * are provided, returns an Record instead of
+ * just a sigle bound function.
+ * @param obj Object to bind to.
+ * @param fns Function(s) to bind.
+ * @returns the bound function(s).
+ */
+export const autobind = <T>(
+  obj: T,
+  fns: OneOrMore<FunctionPropertyNames<T>>
+): any => {
+  if (!Array.isArray(fns)) {
+    return (obj[fns] as any).bind(obj)
+  }
+  const bound = {}
+  for (const fn of fns) {
+    bound[fn as any] = obj[fn as any].bind(obj)
+  }
+  return bound
 }

--- a/packages/core/src/app/core/core.app.ts
+++ b/packages/core/src/app/core/core.app.ts
@@ -14,7 +14,7 @@ import { Process, BaseApp } from '../common'
 import { SimpleConfigManagerProcess, DebugLoggerManagerProcess } from './app'
 import { SimpleDBManagerProcess } from './db'
 import { Web3EthClientProcess, SimpleKeyManagerProcess } from './eth'
-import { SimpleJsonRpcServerProcess } from './net'
+import { SimpleJsonRpcServerProcess, CoreRpcRegistrarProcess } from './net'
 
 export interface CoreAppConfig {
   ETHEREUM_ENDPOINT: string
@@ -35,6 +35,7 @@ export class CoreApp extends BaseApp {
   public readonly ethClient: Process<EthClient>
   public readonly keyManager: Process<KeyManager>
   public readonly rpcServer: Process<RpcServer>
+  public readonly coreRpcRegistrar: Process<void>
 
   /**
    * Creates the app.
@@ -49,11 +50,16 @@ export class CoreApp extends BaseApp {
     this.ethClient = new Web3EthClientProcess(this.configManager)
     this.keyManager = new SimpleKeyManagerProcess(this.dbManager)
     this.rpcServer = new SimpleJsonRpcServerProcess(this.configManager)
+    this.coreRpcRegistrar = new CoreRpcRegistrarProcess(
+      this.rpcServer,
+      this.keyManager
+    )
 
     this.register('ConfigManager', this.configManager)
     this.register('LogCollector', this.loggerManager)
     this.register('DBManager', this.dbManager)
     this.register('EthClient', this.ethClient)
     this.register('KeyManager', this.keyManager)
+    this.register('CoreRpcRegistrar', this.coreRpcRegistrar)
   }
 }

--- a/packages/core/src/app/core/net/index.ts
+++ b/packages/core/src/app/core/net/index.ts
@@ -1,2 +1,4 @@
+export * from './rpc-registrar.process'
+export * from './rpc-registrar'
 export * from './rpc-server.process'
 export * from './rpc-server'

--- a/packages/core/src/app/core/net/rpc-registrar.process.ts
+++ b/packages/core/src/app/core/net/rpc-registrar.process.ts
@@ -1,0 +1,38 @@
+/* Internal Imports */
+import { RpcServer, KeyManager } from '../../../interfaces'
+import { Process } from '../../common'
+import { CoreRpcRegistrar } from './rpc-registrar'
+
+/**
+ * Process that binds RPC methods to specific methods
+ * inside the core app.
+ */
+export class CoreRpcRegistrarProcess extends Process<void> {
+  /**
+   * Creates the process.
+   * @param rpcServer RPC server to register things to.
+   * @param keyManager Key management process.
+   */
+  constructor(
+    private rpcServer: Process<RpcServer>,
+    private keyManager: Process<KeyManager>
+  ) {
+    super()
+  }
+
+  /**
+   * Binds the relevant RPC methods.
+   * Waits for RPC server and other processes
+   * to be ready before binding methods.
+   */
+  protected async onStart(): Promise<void> {
+    await this.rpcServer.waitUntilStarted()
+    await this.keyManager.waitUntilStarted()
+
+    const registrar = new CoreRpcRegistrar(
+      this.rpcServer.subject,
+      this.keyManager.subject
+    )
+    registrar.register()
+  }
+}

--- a/packages/core/src/app/core/net/rpc-registrar.ts
+++ b/packages/core/src/app/core/net/rpc-registrar.ts
@@ -1,0 +1,28 @@
+/* Internal Imports */
+import { RpcServer, KeyManager } from '../../../interfaces'
+import { registerBound } from '../../common'
+
+/**
+ * Registers RPC methods for the core app.
+ */
+export class CoreRpcRegistrar {
+  /**
+   * Creates the registrar.
+   * @param rpcServer Server to register to.
+   * @param keyManager Key manager instance.
+   */
+  constructor(private rpcServer: RpcServer, private keyManager: KeyManager) {}
+
+  /**
+   * Registers RPC methods.
+   */
+  public register(): void {
+    registerBound(this.rpcServer, this.keyManager, [
+      'createAccount',
+      'getAccounts',
+      'lockAccount',
+      'sign',
+      'unlockAccount',
+    ])
+  }
+}

--- a/packages/core/src/interfaces/common/utils/index.ts
+++ b/packages/core/src/interfaces/common/utils/index.ts
@@ -1,3 +1,3 @@
 export * from './logger.interface'
 export * from './state.interface'
-export * from './type.interface'
+export * from './misc.interface'

--- a/packages/core/src/interfaces/common/utils/misc.interface.ts
+++ b/packages/core/src/interfaces/common/utils/misc.interface.ts
@@ -1,0 +1,7 @@
+export type Type<T> = new (...args: any[]) => T
+
+export type FunctionPropertyNames<T> = {
+  [K in keyof T]: T[K] extends Function ? K : never
+}[keyof T]
+
+export type OneOrMore<T> = T[] | T

--- a/packages/core/src/interfaces/common/utils/type.interface.ts
+++ b/packages/core/src/interfaces/common/utils/type.interface.ts
@@ -1,1 +1,0 @@
-export type Type<T> = new (...args: any[]) => T


### PR DESCRIPTION
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request.
Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Plasma Group Contributing Guide and Code of Conduct](https://github.com/plasma-group/pigi/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.

------------------------------------------------------------------------

## Description
We somehow need to register specific methods to the RPC server. Otherwise the RPC server doesn't expose any methods! There are two main trains of thought here - either each individual process registers methods to the RPC server itself, or we have something else do the registration on those processes' behalf. 

For now I think it's better to go with the latter option. IMO it's much cleaner because the individual processes don't become coupled to the RPC server. To that end I've gone ahead and added an "RPC registrar" - a process responsible for registering methods to the RPC server. I deliberately split the registrar into two components, a "registrar" that actually registers the methods and a process that simply creates/runs the registrar. My main reasoning for this was that it's a easier to test, we always want to separate out the business logic from the thing that initializes/runs that logic.
