### PR TITLE
Adding in-memory plasma block generation

### DIFF
--- a/packages/core/src/app/block-production/index.ts
+++ b/packages/core/src/app/block-production/index.ts
@@ -1,1 +1,3 @@
 export * from './merkle-interval-tree'
+export * from './state-interval-tree'
+export * from './plasma-block-tree'

--- a/packages/core/src/app/block-production/merkle-interval-tree.ts
+++ b/packages/core/src/app/block-production/merkle-interval-tree.ts
@@ -256,13 +256,16 @@ export class MerkleIntervalTree {
       computed = this.parent(left, right) // note: this checks left.index < right.index
     }
 
+    const implicitStart = leafPosition === 0 ? new BigNum(0) : leafNode.index
+    const implicitEnd = firstRightSibling
+      ? firstRightSibling.index
+      : MerkleIntervalTree.emptyNode(leafNode.index.length).index // messy way to get the max index, TODO clean
+
     return {
       root: computed,
       bounds: {
-        implicitStart: leafPosition === 0 ? new BigNum(0) : leafNode.index,
-        implicitEnd: firstRightSibling
-          ? firstRightSibling.index
-          : MerkleIntervalTree.emptyNode(leafNode.index.length).index, // messy way to get the max index, TODO clean
+        implicitStart: new BigNum(implicitStart),
+        implicitEnd: new BigNum(implicitEnd),
       },
     }
   }

--- a/packages/core/src/app/block-production/merkle-interval-tree.ts
+++ b/packages/core/src/app/block-production/merkle-interval-tree.ts
@@ -87,7 +87,7 @@ export class MerkleIntervalTree {
   /**
    * Calculates the leaf MerkleIntervalTreeNode for a given data block.
    */
-  public parseLeaf(dataBlock: any): MerkleIntervalTreeNode {
+  public generateLeafNode(dataBlock: any): MerkleIntervalTreeNode {
     return dataBlock
   }
 
@@ -96,7 +96,7 @@ export class MerkleIntervalTree {
    */
   public generateLeafNodes() {
     for (let i = 0; i < this.dataBlocks.length; i++) {
-      this.levels[0][i] = this.parseLeaf(this.dataBlocks[i])
+      this.levels[0][i] = this.generateLeafNode(this.dataBlocks[i])
     }
   }
 

--- a/packages/core/src/app/block-production/plasma-block-tree.ts
+++ b/packages/core/src/app/block-production/plasma-block-tree.ts
@@ -82,6 +82,10 @@ export class PlasmaBlock extends MerkleIntervalTree {
       stateTreeInclusionProof
     )
 
+    if (stateUpdateRootAndBounds.bounds.end.lt(stateUpdate.range.end)) {
+        throw new Error('state update inclusion failed: inclusion proof bounds: ' + stateUpdateRootAndBounds.bounds + ' disagrees with SU range: ' + stateUpdate.range)
+    }
+
     const addressLeafHash: Buffer = stateUpdateRootAndBounds.root.hash
     const addressLeafIndex: Buffer = Buffer.from(
       stateUpdate.depositAddress.slice(2),

--- a/packages/core/src/app/block-production/plasma-block-tree.ts
+++ b/packages/core/src/app/block-production/plasma-block-tree.ts
@@ -82,8 +82,13 @@ export class PlasmaBlock extends MerkleIntervalTree {
       stateTreeInclusionProof
     )
 
-    if (stateUpdateRootAndBounds.bounds.end.lt(stateUpdate.range.end)) {
-        throw new Error('state update inclusion failed: inclusion proof bounds: ' + stateUpdateRootAndBounds.bounds + ' disagrees with SU range: ' + stateUpdate.range)
+    if (stateUpdateRootAndBounds.bounds.implicitEnd.lt(stateUpdate.range.end)) {
+      throw new Error(
+        'state update inclusion failed: inclusion proof bounds: ' +
+          stateUpdateRootAndBounds.bounds +
+          ' disagrees with SU range: ' +
+          stateUpdate.range
+      )
     }
 
     const addressLeafHash: Buffer = stateUpdateRootAndBounds.root.hash

--- a/packages/core/src/app/block-production/plasma-block-tree.ts
+++ b/packages/core/src/app/block-production/plasma-block-tree.ts
@@ -1,0 +1,61 @@
+
+import { MerkleIntervalTree, MerkleIntervalTreeNode, MerkleStateIntervalTree }  from './'
+import { AbiStateUpdate } from '../'
+
+export interface SubtreeContents {
+    address: Buffer
+    stateUpdates: AbiStateUpdate[]
+}
+
+export class PlasmaBlock extends MerkleIntervalTree {
+public subtrees: MerkleStateIntervalTree[]
+
+public parseLeaves() {
+    this.subtrees = []
+    super.parseLeaves()
+}
+
+public parseLeaf(subtree: SubtreeContents): MerkleIntervalTreeNode {
+    const merkleStateIntervalTree = new MerkleStateIntervalTree(subtree.stateUpdates)
+    this.subtrees.push(merkleStateIntervalTree)
+    return new MerkleIntervalTreeNode(merkleStateIntervalTree.root().hash, subtree.address)
+}
+
+public getStateUpdateInclusionProof(
+    stateUpdatePosition: number,
+    addressPosition: number
+): any {
+    return {
+    stateTreeInclusionProof: this.subtrees[addressPosition].getInclusionProof(stateUpdatePosition),
+    addressTreeInclusionProof: this.getInclusionProof(addressPosition)
+    }
+}
+
+public static verifyStateUpdateInclusionProof(
+    stateUpdate: AbiStateUpdate,
+    stateTreeInclusionProof: MerkleIntervalTreeNode[],
+    stateUpdatePosition: number,
+    addressTreeInclusionProof: MerkleIntervalTreeNode[],
+    addressPosition: number,
+    blockRootHash: Buffer
+): any {
+    const leafNodeHash: Buffer = MerkleIntervalTree.hash(Buffer.from(stateUpdate.encoded))
+    const leafNodeIndex: Buffer = stateUpdate.range.start.toBuffer('be', MerkleStateIntervalTree.STATE_ID_LENGTH)
+    const stateLeafNode: MerkleIntervalTreeNode = new MerkleIntervalTreeNode(leafNodeHash, leafNodeIndex)
+    const stateUpdateRootAndBounds = MerkleIntervalTree.getRootAndBounds(
+    stateLeafNode,
+    stateUpdatePosition,
+    stateTreeInclusionProof
+    )
+
+    const addressLeafHash: Buffer = stateUpdateRootAndBounds.root.hash
+    const addressLeafIndex: Buffer = Buffer.from(stateUpdate.depositAddress.slice(2), 'hex')
+    const addressLeafNode: MerkleIntervalTreeNode = new MerkleIntervalTreeNode(addressLeafHash, addressLeafIndex)
+    return MerkleIntervalTree.verify(
+    addressLeafNode,
+    addressPosition,
+    addressTreeInclusionProof,
+    blockRootHash
+    )
+}
+}

--- a/packages/core/src/app/block-production/plasma-block-tree.ts
+++ b/packages/core/src/app/block-production/plasma-block-tree.ts
@@ -6,9 +6,9 @@ import { SubtreeContents } from '../../types'
 export class PlasmaBlock extends MerkleIntervalTree {
 public subtrees: MerkleStateIntervalTree[]
 
-public parseLeaves() {
+public generateLeafNodes() {
     this.subtrees = []
-    super.parseLeaves()
+    super.generateLeafNodes()
 }
 
 public parseLeaf(subtree: SubtreeContents): MerkleIntervalTreeNode {
@@ -39,19 +39,19 @@ public static verifyStateUpdateInclusionProof(
     const leafNodeIndex: Buffer = stateUpdate.range.start.toBuffer('be', MerkleStateIntervalTree.STATE_ID_LENGTH)
     const stateLeafNode: MerkleIntervalTreeNode = new MerkleIntervalTreeNode(leafNodeHash, leafNodeIndex)
     const stateUpdateRootAndBounds = MerkleIntervalTree.getRootAndBounds(
-    stateLeafNode,
-    stateUpdatePosition,
-    stateTreeInclusionProof
+        stateLeafNode,
+        stateUpdatePosition,
+        stateTreeInclusionProof
     )
 
     const addressLeafHash: Buffer = stateUpdateRootAndBounds.root.hash
     const addressLeafIndex: Buffer = Buffer.from(stateUpdate.depositAddress.slice(2), 'hex')
     const addressLeafNode: MerkleIntervalTreeNode = new MerkleIntervalTreeNode(addressLeafHash, addressLeafIndex)
     return MerkleIntervalTree.verify(
-    addressLeafNode,
-    addressPosition,
-    addressTreeInclusionProof,
-    blockRootHash
+        addressLeafNode,
+        addressPosition,
+        addressTreeInclusionProof,
+        blockRootHash
     )
 }
 }

--- a/packages/core/src/app/block-production/plasma-block-tree.ts
+++ b/packages/core/src/app/block-production/plasma-block-tree.ts
@@ -1,76 +1,101 @@
 /*Internal Imports */
-import { MerkleIntervalTree, MerkleIntervalTreeNode, MerkleStateIntervalTree }  from './'
+import {
+  MerkleIntervalTree,
+  MerkleIntervalTreeNode,
+  MerkleStateIntervalTree,
+} from './'
 import { AbiStateUpdate } from '../'
 import { SubtreeContents } from '../../types'
 
 export class PlasmaBlock extends MerkleIntervalTree {
-public subtrees: MerkleStateIntervalTree[]
+  public subtrees: MerkleStateIntervalTree[]
 
-public generateLeafNodes() {
+  public generateLeafNodes() {
     this.subtrees = []
     super.generateLeafNodes()
-}
+  }
 
-// The "leaf node" for the plasma block is itself the root hash of a state update tree.
-// Thus, its data blocks are in fact entire subtrees.
-public generateLeafNode(subtree: SubtreeContents): MerkleIntervalTreeNode {
+  // The "leaf node" for the plasma block is itself the root hash of a state update tree.
+  // Thus, its data blocks are in fact entire subtrees.
+  public generateLeafNode(subtree: SubtreeContents): MerkleIntervalTreeNode {
     // Create a state subtree for these state updates.
-    const merkleStateIntervalTree = new MerkleStateIntervalTree(subtree.stateUpdates)
+    const merkleStateIntervalTree = new MerkleStateIntervalTree(
+      subtree.stateUpdates
+    )
     // Store the state subtree.
     this.subtrees.push(merkleStateIntervalTree)
     // Return a leaf node with the root of the state tree and an index of the depositAddress.
-    return new MerkleIntervalTreeNode(merkleStateIntervalTree.root().hash, subtree.assetId)
-}
+    return new MerkleIntervalTreeNode(
+      merkleStateIntervalTree.root().hash,
+      subtree.assetId
+    )
+  }
 
-/**
- * Returns a double inclusion proof which demonstrates the existence of a state update within the plasma block.
- * @param stateUpdatePosition index of the state udpate in the state subtree of the block.
- * @param assetIdPosition index of the assetId in the top-level asset id of the block
- */
-public getStateUpdateInclusionProof(
+  /**
+   * Returns a double inclusion proof which demonstrates the existence of a state update within the plasma block.
+   * @param stateUpdatePosition index of the state udpate in the state subtree of the block.
+   * @param assetIdPosition index of the assetId in the top-level asset id of the block
+   */
+  public getStateUpdateInclusionProof(
     stateUpdatePosition: number,
     assetIdPosition: number
-): any {
+  ): any {
     return {
-    stateTreeInclusionProof: this.subtrees[assetIdPosition].getInclusionProof(stateUpdatePosition),
-    addressTreeInclusionProof: this.getInclusionProof(assetIdPosition)
+      stateTreeInclusionProof: this.subtrees[assetIdPosition].getInclusionProof(
+        stateUpdatePosition
+      ),
+      addressTreeInclusionProof: this.getInclusionProof(assetIdPosition),
     }
-}
+  }
 
-/**
- * Verifies a double inclusion proof which demonstrates the existence of a state update within the plasma block.
- * @param stateUpdate 
- * @param stateTreeInclusionProof 
- * @param stateUpdatePosition 
- * @param addressTreeInclusionProof 
- * @param assetIdPosition 
- * @param blockRootHash 
- */
-public static verifyStateUpdateInclusionProof(
+  /**
+   * Verifies a double inclusion proof which demonstrates the existence of a state update within the plasma block.
+   * @param stateUpdate
+   * @param stateTreeInclusionProof
+   * @param stateUpdatePosition
+   * @param addressTreeInclusionProof
+   * @param assetIdPosition
+   * @param blockRootHash
+   */
+  public static verifyStateUpdateInclusionProof(
     stateUpdate: AbiStateUpdate,
     stateTreeInclusionProof: MerkleIntervalTreeNode[],
     stateUpdatePosition: number,
     addressTreeInclusionProof: MerkleIntervalTreeNode[],
     assetIdPosition: number,
     blockRootHash: Buffer
-): any {
-    const leafNodeHash: Buffer = MerkleIntervalTree.hash(Buffer.from(stateUpdate.encoded))
-    const leafNodeIndex: Buffer = stateUpdate.range.start.toBuffer('be', MerkleStateIntervalTree.STATE_ID_LENGTH)
-    const stateLeafNode: MerkleIntervalTreeNode = new MerkleIntervalTreeNode(leafNodeHash, leafNodeIndex)
+  ): any {
+    const leafNodeHash: Buffer = MerkleIntervalTree.hash(
+      Buffer.from(stateUpdate.encoded)
+    )
+    const leafNodeIndex: Buffer = stateUpdate.range.start.toBuffer(
+      'be',
+      MerkleStateIntervalTree.STATE_ID_LENGTH
+    )
+    const stateLeafNode: MerkleIntervalTreeNode = new MerkleIntervalTreeNode(
+      leafNodeHash,
+      leafNodeIndex
+    )
     const stateUpdateRootAndBounds = MerkleIntervalTree.getRootAndBounds(
-        stateLeafNode,
-        stateUpdatePosition,
-        stateTreeInclusionProof
+      stateLeafNode,
+      stateUpdatePosition,
+      stateTreeInclusionProof
     )
 
     const addressLeafHash: Buffer = stateUpdateRootAndBounds.root.hash
-    const addressLeafIndex: Buffer = Buffer.from(stateUpdate.depositAddress.slice(2), 'hex')
-    const addressLeafNode: MerkleIntervalTreeNode = new MerkleIntervalTreeNode(addressLeafHash, addressLeafIndex)
-    return MerkleIntervalTree.verify(
-        addressLeafNode,
-        assetIdPosition,
-        addressTreeInclusionProof,
-        blockRootHash
+    const addressLeafIndex: Buffer = Buffer.from(
+      stateUpdate.depositAddress.slice(2),
+      'hex'
     )
-}
+    const addressLeafNode: MerkleIntervalTreeNode = new MerkleIntervalTreeNode(
+      addressLeafHash,
+      addressLeafIndex
+    )
+    return MerkleIntervalTree.verify(
+      addressLeafNode,
+      assetIdPosition,
+      addressTreeInclusionProof,
+      blockRootHash
+    )
+  }
 }

--- a/packages/core/src/app/block-production/plasma-block-tree.ts
+++ b/packages/core/src/app/block-production/plasma-block-tree.ts
@@ -1,11 +1,7 @@
-
+/*Internal Imports */
 import { MerkleIntervalTree, MerkleIntervalTreeNode, MerkleStateIntervalTree }  from './'
 import { AbiStateUpdate } from '../'
-
-export interface SubtreeContents {
-    address: Buffer
-    stateUpdates: AbiStateUpdate[]
-}
+import { SubtreeContents } from '../../types'
 
 export class PlasmaBlock extends MerkleIntervalTree {
 public subtrees: MerkleStateIntervalTree[]

--- a/packages/core/src/app/block-production/state-interval-tree.ts
+++ b/packages/core/src/app/block-production/state-interval-tree.ts
@@ -1,0 +1,12 @@
+import { MerkleIntervalTree, MerkleIntervalTreeNode }  from './'
+import { AbiStateUpdate } from '../'
+
+export class MerkleStateIntervalTree extends MerkleIntervalTree {
+    public static STATE_ID_LENGTH = 16
+
+    public parseLeaf(stateUpdate: AbiStateUpdate): MerkleIntervalTreeNode {
+      const hash = MerkleIntervalTree.hash(Buffer.from(stateUpdate.encoded))
+      const index = stateUpdate.range.start.toBuffer('be', MerkleStateIntervalTree.STATE_ID_LENGTH)
+      return new MerkleIntervalTreeNode(hash, index)
+    }
+  }

--- a/packages/core/src/app/block-production/state-interval-tree.ts
+++ b/packages/core/src/app/block-production/state-interval-tree.ts
@@ -1,14 +1,17 @@
-import { MerkleIntervalTree, MerkleIntervalTreeNode }  from './'
+import { MerkleIntervalTree, MerkleIntervalTreeNode } from './'
 import { AbiStateUpdate } from '../'
 
 export class MerkleStateIntervalTree extends MerkleIntervalTree {
-    public static STATE_ID_LENGTH = 16
+  public static STATE_ID_LENGTH = 16
 
-    // To create a state update tree from the generic interval tree, 
-    // we simply define how to generate a leaf from its SU data block.
-    public generateLeafNode(stateUpdate: AbiStateUpdate): MerkleIntervalTreeNode {
-        const hash = MerkleIntervalTree.hash(Buffer.from(stateUpdate.encoded))
-        const index = stateUpdate.range.start.toBuffer('be', MerkleStateIntervalTree.STATE_ID_LENGTH)
-        return new MerkleIntervalTreeNode(hash, index)
-    }
+  // To create a state update tree from the generic interval tree,
+  // we simply define how to generate a leaf from its SU data block.
+  public generateLeafNode(stateUpdate: AbiStateUpdate): MerkleIntervalTreeNode {
+    const hash = MerkleIntervalTree.hash(Buffer.from(stateUpdate.encoded))
+    const index = stateUpdate.range.start.toBuffer(
+      'be',
+      MerkleStateIntervalTree.STATE_ID_LENGTH
+    )
+    return new MerkleIntervalTreeNode(hash, index)
+  }
 }

--- a/packages/core/src/app/block-production/state-interval-tree.ts
+++ b/packages/core/src/app/block-production/state-interval-tree.ts
@@ -5,8 +5,8 @@ export class MerkleStateIntervalTree extends MerkleIntervalTree {
     public static STATE_ID_LENGTH = 16
 
     public parseLeaf(stateUpdate: AbiStateUpdate): MerkleIntervalTreeNode {
-      const hash = MerkleIntervalTree.hash(Buffer.from(stateUpdate.encoded))
-      const index = stateUpdate.range.start.toBuffer('be', MerkleStateIntervalTree.STATE_ID_LENGTH)
-      return new MerkleIntervalTreeNode(hash, index)
+        const hash = MerkleIntervalTree.hash(Buffer.from(stateUpdate.encoded))
+        const index = stateUpdate.range.start.toBuffer('be', MerkleStateIntervalTree.STATE_ID_LENGTH)
+        return new MerkleIntervalTreeNode(hash, index)
     }
-  }
+}

--- a/packages/core/src/app/block-production/state-interval-tree.ts
+++ b/packages/core/src/app/block-production/state-interval-tree.ts
@@ -4,7 +4,9 @@ import { AbiStateUpdate } from '../'
 export class MerkleStateIntervalTree extends MerkleIntervalTree {
     public static STATE_ID_LENGTH = 16
 
-    public parseLeaf(stateUpdate: AbiStateUpdate): MerkleIntervalTreeNode {
+    // To create a state update tree from the generic interval tree, 
+    // we simply define how to generate a leaf from its SU data block.
+    public generateLeafNode(stateUpdate: AbiStateUpdate): MerkleIntervalTreeNode {
         const hash = MerkleIntervalTree.hash(Buffer.from(stateUpdate.encoded))
         const index = stateUpdate.range.start.toBuffer('be', MerkleStateIntervalTree.STATE_ID_LENGTH)
         return new MerkleIntervalTreeNode(hash, index)

--- a/packages/core/src/types/block-production.types.ts
+++ b/packages/core/src/types/block-production.types.ts
@@ -5,6 +5,6 @@ import BigNumber = require('bn.js')
 import { AbiStateUpdate } from '../app'
 
 export interface SubtreeContents {
-  address: Buffer
+  assetId: Buffer
   stateUpdates: AbiStateUpdate[]
 }

--- a/packages/core/src/types/block-production.types.ts
+++ b/packages/core/src/types/block-production.types.ts
@@ -1,15 +1,10 @@
 /* External Imports */
 import BigNumber = require('bn.js')
 
-export interface MerkleIntervalTreeLeafNode {
-  start: BigNumber
-  end: BigNumber
-  data: Buffer
-}
+/* Internal Imports */
+import { AbiStateUpdate } from '../app'
 
-export interface MerkleIntervalTreeInternalNode {
-  index: BigNumber
-  hash: Buffer
+export interface SubtreeContents {
+  address: Buffer
+  stateUpdates: AbiStateUpdate[]
 }
-
-export type MerkleIntervalTreeInclusionProof = MerkleIntervalTreeInternalNode[]

--- a/packages/core/test/app/block-production/merkle-interval-tree.spec.ts
+++ b/packages/core/test/app/block-production/merkle-interval-tree.spec.ts
@@ -11,8 +11,6 @@ import {
     MerkleIntervalTree, MerkleIntervalTreeNode, MerkleStateIntervalTree, PlasmaBlock
   }  from '../../../src/app/'
 
-import { AssertionError } from 'assert'
-
 describe.only('merkle-index-tree', () => {
   describe('MerkleIntervalTreeNode', () => {
     it('should concatenate index and hash after construction', async() => {

--- a/packages/core/test/app/block-production/merkle-interval-tree.spec.ts
+++ b/packages/core/test/app/block-production/merkle-interval-tree.spec.ts
@@ -1,331 +1,143 @@
 import { should } from '../../setup'
 
 /* External Imports */
-import BigNumber = require('bn.js')
+import debug from 'debug'
+const log = debug('test:info:merkle-index-tree')
+import BigNum = require('bn.js')
 
 /* Internal Imports */
-import { MerkleIntervalTree } from '../../../src/app'
-
 import {
-  MerkleIntervalTreeLeafNode,
-  MerkleIntervalTreeInternalNode,
-  MerkleIntervalTreeInclusionProof,
-} from '../../../src/types'
+    AbiStateUpdate, AbiStateObject, AbiRange,
+  }  from '../../../src/app/'
+import {
+  MerkleIntervalTree, MerkleIntervalTreeNode
+  // MerkleIntervalTree, MerkleStateIntervalTree, PlasmaBlock, MerkleIntervalTreeNode
+} from '../../../src/app/'
 
-/**
- * Converts a string to a hex buffer.
- * @param value String value to convert.
- * @returns the string as a hex buffer.
- */
-const hexify = (value: string): Buffer => {
-  return Buffer.from(value, 'hex')
-}
+import { AssertionError } from 'assert'
 
-describe('MerkleIntervalTree', () => {
-  describe('construction', () => {
-    it('should be created correctly with no leaves', () => {
-      const tree = new MerkleIntervalTree()
-
-      const root = tree.getRoot()
-      const levels = tree.getLevels()
-
-      should.not.exist(root)
-      levels.should.deep.equal([[]])
+describe.only('merkle-index-tree', () => {
+  describe('MerkleIntervalTreeNode', () => {
+    it('should concatenate index and hash after construction', async() => {
+      const node = new MerkleIntervalTreeNode(Buffer.from([255]), Buffer.from([0])) 
+      log('New merkle index tree node:', node)
+      const expected = Buffer.concat([Buffer.from([255]), Buffer.from([0])])
+      node.data.should.deep.equal(expected)
     })
-
-    it('should be created correctly with one leaf', () => {
-      const tree = new MerkleIntervalTree([
-        {
-          start: new BigNumber(0),
-          end: new BigNumber(100),
-          data: hexify('1234'),
-        },
-      ])
-
-      const root = tree.getRoot()
-
-      root.should.deep.equal({
-        index: new BigNumber(0),
-        hash: hexify(
-          '4d7654430bd809384e15ef3e842aad2449b6310b25c652a220af74716b37e0ae'
-        ),
+  })
+  describe('MerkleIntervalTree', () => {
+    describe('parent', () => {
+      it('should return the correct parent', async() => {
+        const left = new MerkleIntervalTreeNode(Buffer.from([13]), Buffer.from([10])) 
+        const right = new MerkleIntervalTreeNode(Buffer.from([31]), Buffer.from([15])) 
+        const parent = MerkleIntervalTree.parent(left, right)
+        // We calculated the hash by hand.
+        parent.data.toString('hex').should.equal('69b053cd194c51ff15ac9db85fc581c4457a7160c78d878e7c5b84f4c1fbb9140a')
+      })
+      it('should throw if left & right nodes are out of order', async() => {
+        const left = new MerkleIntervalTreeNode(Buffer.from([13]), Buffer.from([15])) 
+        const right = new MerkleIntervalTreeNode(Buffer.from([31]), Buffer.from([10])) 
+        const parentCall = () => MerkleIntervalTree.parent(left, right)
+        parentCall.should.throw()
       })
     })
-
-    it('should be created correctly with two leaves', () => {
-      const tree = new MerkleIntervalTree([
-        {
-          start: new BigNumber(0),
-          end: new BigNumber(100),
-          data: hexify('1234'),
-        },
-        {
-          start: new BigNumber(100),
-          end: new BigNumber(200),
-          data: hexify('5678'),
-        },
-      ])
-
-      const root = tree.getRoot()
-
-      root.should.deep.equal({
-        index: new BigNumber(0),
-        hash: hexify(
-          'e1b53cab461af771ad8d060145d2e27a04ee7c2e671efe4feac748de8cef1fc5'
-        ),
-      })
+    it('should generate a generic tree', async() => {
+      const leaves = []
+      for (let i = 0; i < 4; i++) {
+        leaves.push(new MerkleIntervalTreeNode(Buffer.from([Math.floor(Math.random()*100)]), Buffer.from([i])))
+      }
+      const IntervalTree = new MerkleIntervalTree(leaves)
+      log(IntervalTree.levels)
+      log(IntervalTree.root)
     })
-
-    it('should throw if trying to create with overlapping leaves', () => {
-      should.Throw(() => {
-        new MerkleIntervalTree([
-          {
-            start: new BigNumber(0),
-            end: new BigNumber(100),
-            data: hexify('1234'),
-          },
-          {
-            start: new BigNumber(50),
-            end: new BigNumber(150),
-            data: hexify('5678'),
-          },
-        ])
-      }, 'Merkle Interval Tree leaves must not overlap.')
-    })
-
-    it('should throw if trying to create with an invalid leaf', () => {
-      should.Throw(() => {
-        new MerkleIntervalTree([
-          {
-            start: new BigNumber(100),
-            end: new BigNumber(0),
-            data: hexify('1234'),
-          },
-        ])
-      }, 'Merkle Interval Tree leaves must not overlap.')
+    it('should generate and verify inclusion proofs for generic tree', async() => {
+      const leaves = []
+      for (let i = 0; i < 4; i++) {
+        leaves.push(new MerkleIntervalTreeNode(Buffer.from([Math.floor(Math.random()*100)]), Buffer.from([i])))
+      }
+      const IntervalTree = new MerkleIntervalTree(leaves)
+      const leafPosition = 3
+      const inclusionProof = IntervalTree.getInclusionProof(leafPosition)
+      console.log('tree: ', IntervalTree.levels)
+      console.log('inclusopn proof length is: ', inclusionProof.length)
+      MerkleIntervalTree.verify(
+        leaves[leafPosition],
+        leafPosition,
+        inclusionProof,
+        IntervalTree.root().hash
+      )
     })
   })
-
-  describe('checkInclusionProof', () => {
-    it('should correctly verify a valid proof', () => {
-      const leaf: MerkleIntervalTreeLeafNode = {
-        start: new BigNumber(0),
-        end: new BigNumber(100),
-        data: hexify('1234'),
-      }
-      const inclusionProof: MerkleIntervalTreeInclusionProof = [
-        {
-          index: new BigNumber(100),
-          hash: hexify(
-            '05cc573cfe77fad641c92f62241633a64f5656275753ae9b8bf67b44f29a777b'
-          ),
-        },
-      ]
-      const rootHash = hexify(
-        'e1b53cab461af771ad8d060145d2e27a04ee7c2e671efe4feac748de8cef1fc5'
-      )
-
-      const valid = new MerkleIntervalTree().checkInclusionProof(
-        leaf,
-        0,
-        inclusionProof,
-        rootHash
-      )
-
-      valid.should.be.true
-    })
-
-    it('should correctly reject a proof with the wrong root', () => {
-      const leaf: MerkleIntervalTreeLeafNode = {
-        start: new BigNumber(0),
-        end: new BigNumber(100),
-        data: hexify('1234'),
-      }
-      const inclusionProof: MerkleIntervalTreeInclusionProof = [
-        {
-          index: new BigNumber(100),
-          hash: hexify(
-            '05cc573cfe77fad641c92f62241633a64f5656275753ae9b8bf67b44f29a777b'
-          ),
-        },
-      ]
-      const rootHash = hexify(
-        '0000000000000000000000000000000000000000000000000000000000000000'
-      )
-
-      const valid = new MerkleIntervalTree().checkInclusionProof(
-        leaf,
-        0,
-        inclusionProof,
-        rootHash
-      )
-
-      valid.should.be.false
-    })
-
-    it('should correctly reject a proof with an invalid leaf range', () => {
-      const leaf: MerkleIntervalTreeLeafNode = {
-        start: new BigNumber(100),
-        end: new BigNumber(0),
-        data: hexify('1234'),
-      }
-      const inclusionProof: MerkleIntervalTreeInclusionProof = [
-        {
-          index: new BigNumber(100),
-          hash: hexify(
-            '0000000000000000000000000000000000000000000000000000000000000000'
-          ),
-        },
-      ]
-      const rootHash = hexify(
-        'e1b53cab461af771ad8d060145d2e27a04ee7c2e671efe4feac748de8cef1fc5'
-      )
-
-      should.Throw(() => {
-        new MerkleIntervalTree().checkInclusionProof(
-          leaf,
-          0,
-          inclusionProof,
-          rootHash
-        )
-      }, 'Merkle Interval Tree leaves must not overlap.')
-    })
-
-    it('should correctly reject a proof with an invalid sibling hash', () => {
-      const leaf: MerkleIntervalTreeLeafNode = {
-        start: new BigNumber(0),
-        end: new BigNumber(100),
-        data: hexify('1234'),
-      }
-      const inclusionProof: MerkleIntervalTreeInclusionProof = [
-        {
-          index: new BigNumber(100),
-          hash: hexify(
-            '0000000000000000000000000000000000000000000000000000000000000000'
-          ),
-        },
-      ]
-      const rootHash = hexify(
-        'e1b53cab461af771ad8d060145d2e27a04ee7c2e671efe4feac748de8cef1fc5'
-      )
-
-      const valid = new MerkleIntervalTree().checkInclusionProof(
-        leaf,
-        0,
-        inclusionProof,
-        rootHash
-      )
-
-      valid.should.be.false
-    })
-
-    it('should correctly reject a proof with an overlapping sibling', () => {
-      const leaf: MerkleIntervalTreeLeafNode = {
-        start: new BigNumber(0),
-        end: new BigNumber(100),
-        data: hexify('1234'),
-      }
-      const inclusionProof: MerkleIntervalTreeInclusionProof = [
-        {
-          index: new BigNumber(50),
-          hash: hexify(
-            '85c599e3cc2588f5c561128ab27347805ad71c33ea8db75d18823e7117bb9d4b'
-          ),
-        },
-      ]
-      const rootHash = hexify(
-        '224678c7f9b59e07eb036c1914798220b3d1b8d56beb18518f6698d9a0146b84'
-      )
-
-      should.Throw(() => {
-        new MerkleIntervalTree().checkInclusionProof(
-          leaf,
-          0,
-          inclusionProof,
-          rootHash
-        )
-      }, 'Invalid Merkle Interval Tree proof -- potential intersection detected.')
-    })
-
-    it('should correctly reject a proof with a non-monotonic right sibling', () => {
-      const leaf: MerkleIntervalTreeLeafNode = {
-        start: new BigNumber(0),
-        end: new BigNumber(100),
-        data: hexify('1234'),
-      }
-      const inclusionProof: MerkleIntervalTreeInclusionProof = [
-        {
-          index: new BigNumber(300),
-          hash: hexify(
-            '12c3f0bbe76afc5f6aefd5b3584fa90bc9e49f945ebd6fe5f4b86205b44e2b71'
-          ),
-        },
-        {
-          index: new BigNumber(100),
-          hash: hexify(
-            '89e643ad387e04a149ba8c0d7b62ac42ff32c212183035b1a7a720c0ee24699e'
-          ),
-        },
-      ]
-      const rootHash = hexify(
-        'd40fc6083f76dd701db66dfbc465a945d8148067181c4c6e007e8f02c90853e3'
-      )
-
-      should.Throw(() => {
-        new MerkleIntervalTree().checkInclusionProof(
-          leaf,
-          0,
-          inclusionProof,
-          rootHash
-        )
-      }, 'Invalid Merkle Interval Tree proof -- potential intersection detected.')
-    })
-  })
-
-  describe('getInclusionProof', () => {
-    it('should return a valid proof for a node', () => {
-      const tree = new MerkleIntervalTree([
-        {
-          start: new BigNumber(0),
-          end: new BigNumber(100),
-          data: hexify('1234'),
-        },
-        {
-          start: new BigNumber(100),
-          end: new BigNumber(200),
-          data: hexify('5678'),
-        },
-      ])
-
-      const inclusionProof = tree.getInclusionProof(0)
-
-      inclusionProof.should.deep.equal([
-        {
-          index: new BigNumber(100),
-          hash: hexify(
-            '05cc573cfe77fad641c92f62241633a64f5656275753ae9b8bf67b44f29a777b'
-          ),
-        },
-      ])
-    })
-
-    it('should throw an error when getting a proof for a non-existent node', () => {
-      const tree = new MerkleIntervalTree([
-        {
-          start: new BigNumber(0),
-          end: new BigNumber(100),
-          data: hexify('1234'),
-        },
-        {
-          start: new BigNumber(100),
-          end: new BigNumber(200),
-          data: hexify('5678'),
-        },
-      ])
-
-      should.Throw(() => {
-        tree.getInclusionProof(2)
-      }, 'Leaf position is out of bounds.')
-    })
-  })
+//   describe('MerkleStateIntervalTree', () => {
+//     it('should generate a tree without throwing', async() => {
+//       const stateUpdates = []
+//       for (let i = 0; i < 4; i++) {
+//         const stateObject = new AbiStateObject('0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63', '0x123456')
+//         const range = new AbiRange( new BigNum(i*100), new BigNum((i+0.5)* 100) )
+//         const stateUpdate = new AbiStateUpdate(stateObject, range, new BigNum(1), '0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63')
+//         stateUpdates.push(stateUpdate)
+//       }
+//       const merkleStateIntervalTree = new MerkleStateIntervalTree(stateUpdates)
+//       log('root', merkleStateIntervalTree.root())
+//     })
+//   })
+//   describe('PlasmaBlock', () => {
+//     it('should generate a tree without throwing', async() => {
+//       const stateUpdates = []
+//       for (let i = 0; i < 4; i++) {
+//         const stateObject = new AbiStateObject('0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63', '0x123456')
+//         const range = new AbiRange( new BigNum(i*100), new BigNum((i+0.5)* 100) )
+//         const stateUpdate = new AbiStateUpdate(stateObject, range, new BigNum(1), '0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63')
+//         stateUpdates.push(stateUpdate)
+//       }
+//       const blockContents = [
+//         {
+//           address: Buffer.from('bdAd2846585129Fc98538ce21cfcED21dDDE0a63', 'hex'),
+//           stateUpdates
+//         },
+//         {
+//           address: Buffer.from('1dAd2846585129Fc98538ce21cfcED21dDDE0a63', 'hex'),
+//           stateUpdates
+//         },
+//       ]
+//       const plasmaBlock = new PlasmaBlock(blockContents)
+//       log(plasmaBlock)
+//     })
+//     it('should generate and verify a StateUpdateInclusionProof', async() => {
+//       const stateUpdates = []
+//       for (let i = 0; i < 4; i++) {
+//         const stateObject = new AbiStateObject('0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63', '0x123456')
+//         const range = new AbiRange( new BigNum(i*100), new BigNum((i+0.5)* 100) )
+//         const stateUpdate = new AbiStateUpdate(stateObject, range, new BigNum(1), '0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63')
+//         stateUpdates.push(stateUpdate)
+//       }
+//       const blockContents = [
+//         {
+//           address: Buffer.from('bdAd2846585129Fc98538ce21cfcED21dDDE0a63', 'hex'),
+//           stateUpdates
+//         },
+//         {
+//           address: Buffer.from('1dAd2846585129Fc98538ce21cfcED21dDDE0a63', 'hex'),
+//           stateUpdates
+//         },
+//       ]
+//       const plasmaBlock = new PlasmaBlock(blockContents)
+//       console.log('subtree stateLeafNode: ', plasmaBlock.subtrees[1].levels[0][1])
+//       const stateProof = (plasmaBlock.getStateUpdateInclusionProof(1, 1))
+//       console.log('subtree roothash: ', plasmaBlock.subtrees[1].root().hash)
+//       console.log('plasma block levels: ', plasmaBlock.levels)
+//       console.log('state proof: ', stateProof)
+//       console.log(
+//         'staate update verification: ', 
+//         PlasmaBlock.verifyStateUpdateInclusionProof(
+//           blockContents[1].stateUpdates[1],
+//           stateProof.stateTreeInclusionProof,
+//           1,
+//           stateProof.addressTreeInclusionProof,
+//           1,
+//           plasmaBlock.root().hash
+//         )
+//       )
+//     })
+//   })
 })

--- a/packages/core/test/app/block-production/merkle-interval-tree.spec.ts
+++ b/packages/core/test/app/block-production/merkle-interval-tree.spec.ts
@@ -85,11 +85,11 @@ describe.only('merkle-index-tree', () => {
       }
       const blockContents = [
         {
-          address: Buffer.from('1dAd2846585129Fc98538ce21cfcED21dDDE0a63', 'hex'),
+          assetId: Buffer.from('1dAd2846585129Fc98538ce21cfcED21dDDE0a63', 'hex'),
           stateUpdates
         },
         {
-          address: Buffer.from('bdAd2846585129Fc98538ce21cfcED21dDDE0a63', 'hex'),
+          assetId: Buffer.from('bdAd2846585129Fc98538ce21cfcED21dDDE0a63', 'hex'),
           stateUpdates
         }
       ]
@@ -106,11 +106,11 @@ describe.only('merkle-index-tree', () => {
       }
       const blockContents = [
         {
-          address: Buffer.from('1dAd2846585129Fc98538ce21cfcED21dDDE0a63', 'hex'),
+          assetId: Buffer.from('1dAd2846585129Fc98538ce21cfcED21dDDE0a63', 'hex'),
           stateUpdates
         },
         {
-          address: Buffer.from('bdAd2846585129Fc98538ce21cfcED21dDDE0a63', 'hex'),
+          assetId: Buffer.from('bdAd2846585129Fc98538ce21cfcED21dDDE0a63', 'hex'),
           stateUpdates
         }
       ]

--- a/packages/core/test/app/block-production/merkle-interval-tree.spec.ts
+++ b/packages/core/test/app/block-production/merkle-interval-tree.spec.ts
@@ -7,14 +7,22 @@ import BigNum = require('bn.js')
 
 /* Internal Imports */
 import {
-    AbiStateUpdate, AbiStateObject, AbiRange,
-    MerkleIntervalTree, MerkleIntervalTreeNode, MerkleStateIntervalTree, PlasmaBlock
-  }  from '../../../src/app/'
+  AbiStateUpdate,
+  AbiStateObject,
+  AbiRange,
+  MerkleIntervalTree,
+  MerkleIntervalTreeNode,
+  MerkleStateIntervalTree,
+  PlasmaBlock,
+} from '../../../src/app/'
 
 describe('merkle-index-tree', () => {
   describe('MerkleIntervalTreeNode', () => {
-    it('should concatenate index and hash after construction', async() => {
-      const node = new MerkleIntervalTreeNode(Buffer.from([255]), Buffer.from([0])) 
+    it('should concatenate index and hash after construction', async () => {
+      const node = new MerkleIntervalTreeNode(
+        Buffer.from([255]),
+        Buffer.from([0])
+      )
       log('New merkle index tree node:', node)
       const expected = Buffer.concat([Buffer.from([255]), Buffer.from([0])])
       node.data.should.deep.equal(expected)
@@ -22,33 +30,59 @@ describe('merkle-index-tree', () => {
   })
   describe('MerkleIntervalTree', () => {
     describe('parent', () => {
-      it('should return the correct parent', async() => {
-        const left = new MerkleIntervalTreeNode(Buffer.from([13]), Buffer.from([10])) 
-        const right = new MerkleIntervalTreeNode(Buffer.from([31]), Buffer.from([15])) 
+      it('should return the correct parent', async () => {
+        const left = new MerkleIntervalTreeNode(
+          Buffer.from([13]),
+          Buffer.from([10])
+        )
+        const right = new MerkleIntervalTreeNode(
+          Buffer.from([31]),
+          Buffer.from([15])
+        )
         const parent = MerkleIntervalTree.parent(left, right)
         // We calculated the hash by hand.
-        parent.data.toString('hex').should.equal('69b053cd194c51ff15ac9db85fc581c4457a7160c78d878e7c5b84f4c1fbb9140a')
+        parent.data
+          .toString('hex')
+          .should.equal(
+            '69b053cd194c51ff15ac9db85fc581c4457a7160c78d878e7c5b84f4c1fbb9140a'
+          )
       })
-      it('should throw if left & right nodes are out of order', async() => {
-        const left = new MerkleIntervalTreeNode(Buffer.from([13]), Buffer.from([15])) 
-        const right = new MerkleIntervalTreeNode(Buffer.from([31]), Buffer.from([10])) 
+      it('should throw if left & right nodes are out of order', async () => {
+        const left = new MerkleIntervalTreeNode(
+          Buffer.from([13]),
+          Buffer.from([15])
+        )
+        const right = new MerkleIntervalTreeNode(
+          Buffer.from([31]),
+          Buffer.from([10])
+        )
         const parentCall = () => MerkleIntervalTree.parent(left, right)
         parentCall.should.throw()
       })
     })
-    it('should generate a generic tree', async() => {
+    it('should generate a generic tree', async () => {
       const leaves = []
       for (let i = 0; i < 4; i++) {
-        leaves.push(new MerkleIntervalTreeNode(Buffer.from([Math.floor(Math.random()*100)]), Buffer.from([i])))
+        leaves.push(
+          new MerkleIntervalTreeNode(
+            Buffer.from([Math.floor(Math.random() * 100)]),
+            Buffer.from([i])
+          )
+        )
       }
       const IntervalTree = new MerkleIntervalTree(leaves)
       log(IntervalTree.levels)
       log(IntervalTree.root)
     })
-    it('should generate and verify inclusion proofs for generic tree', async() => {
+    it('should generate and verify inclusion proofs for generic tree', async () => {
       const leaves = []
       for (let i = 0; i < 4; i++) {
-        leaves.push(new MerkleIntervalTreeNode(Buffer.from([Math.floor(Math.random()*100)]), Buffer.from([i])))
+        leaves.push(
+          new MerkleIntervalTreeNode(
+            Buffer.from([Math.floor(Math.random() * 100)]),
+            Buffer.from([i])
+          )
+        )
       }
       const IntervalTree = new MerkleIntervalTree(leaves)
       const leafPosition = 3
@@ -62,12 +96,23 @@ describe('merkle-index-tree', () => {
     })
   })
   describe('MerkleStateIntervalTree', () => {
-    it('should generate a tree without throwing', async() => {
+    it('should generate a tree without throwing', async () => {
       const stateUpdates = []
       for (let i = 0; i < 4; i++) {
-        const stateObject = new AbiStateObject('0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63', '0x123456')
-        const range = new AbiRange( new BigNum(i*100), new BigNum((i+0.5)* 100) )
-        const stateUpdate = new AbiStateUpdate(stateObject, range, new BigNum(1), '0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63')
+        const stateObject = new AbiStateObject(
+          '0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63',
+          '0x123456'
+        )
+        const range = new AbiRange(
+          new BigNum(i * 100),
+          new BigNum((i + 0.5) * 100)
+        )
+        const stateUpdate = new AbiStateUpdate(
+          stateObject,
+          range,
+          new BigNum(1),
+          '0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63'
+        )
         stateUpdates.push(stateUpdate)
       }
       const merkleStateIntervalTree = new MerkleStateIntervalTree(stateUpdates)
@@ -75,47 +120,81 @@ describe('merkle-index-tree', () => {
     })
   })
   describe('PlasmaBlock', () => {
-    it('should generate a tree without throwing', async() => {
+    it('should generate a plasma block without throwing', async () => {
       const stateUpdates = []
       for (let i = 0; i < 4; i++) {
-        const stateObject = new AbiStateObject('0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63', '0x123456')
-        const range = new AbiRange( new BigNum(i*100), new BigNum((i+0.5)* 100) )
-        const stateUpdate = new AbiStateUpdate(stateObject, range, new BigNum(1), '0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63')
+        const stateObject = new AbiStateObject(
+          '0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63',
+          '0x123456'
+        )
+        const range = new AbiRange(
+          new BigNum(i * 100),
+          new BigNum((i + 0.5) * 100)
+        )
+        const stateUpdate = new AbiStateUpdate(
+          stateObject,
+          range,
+          new BigNum(1),
+          '0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63'
+        )
         stateUpdates.push(stateUpdate)
       }
       const blockContents = [
         {
-          assetId: Buffer.from('1dAd2846585129Fc98538ce21cfcED21dDDE0a63', 'hex'),
-          stateUpdates
+          assetId: Buffer.from(
+            '1dAd2846585129Fc98538ce21cfcED21dDDE0a63',
+            'hex'
+          ),
+          stateUpdates,
         },
         {
-          assetId: Buffer.from('bdAd2846585129Fc98538ce21cfcED21dDDE0a63', 'hex'),
-          stateUpdates
-        }
+          assetId: Buffer.from(
+            'bdAd2846585129Fc98538ce21cfcED21dDDE0a63',
+            'hex'
+          ),
+          stateUpdates,
+        },
       ]
       const plasmaBlock = new PlasmaBlock(blockContents)
       log(plasmaBlock)
     })
-    it('should generate and verify a StateUpdateInclusionProof', async() => {
+    it('should generate and verify a StateUpdateInclusionProof', async () => {
       const stateUpdates = []
       for (let i = 0; i < 4; i++) {
-        const stateObject = new AbiStateObject('0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63', '0x123456')
-        const range = new AbiRange( new BigNum(i*100), new BigNum((i+0.5)* 100) )
-        const stateUpdate = new AbiStateUpdate(stateObject, range, new BigNum(1), '0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63')
+        const stateObject = new AbiStateObject(
+          '0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63',
+          '0x123456'
+        )
+        const range = new AbiRange(
+          new BigNum(i * 100),
+          new BigNum((i + 0.5) * 100)
+        )
+        const stateUpdate = new AbiStateUpdate(
+          stateObject,
+          range,
+          new BigNum(1),
+          '0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63'
+        )
         stateUpdates.push(stateUpdate)
       }
       const blockContents = [
         {
-          assetId: Buffer.from('1dAd2846585129Fc98538ce21cfcED21dDDE0a63', 'hex'),
-          stateUpdates
+          assetId: Buffer.from(
+            '1dAd2846585129Fc98538ce21cfcED21dDDE0a63',
+            'hex'
+          ),
+          stateUpdates,
         },
         {
-          assetId: Buffer.from('bdAd2846585129Fc98538ce21cfcED21dDDE0a63', 'hex'),
-          stateUpdates
-        }
+          assetId: Buffer.from(
+            'bdAd2846585129Fc98538ce21cfcED21dDDE0a63',
+            'hex'
+          ),
+          stateUpdates,
+        },
       ]
       const plasmaBlock = new PlasmaBlock(blockContents)
-      const stateProof = (plasmaBlock.getStateUpdateInclusionProof(1, 1))
+      const stateProof = plasmaBlock.getStateUpdateInclusionProof(1, 1)
       PlasmaBlock.verifyStateUpdateInclusionProof(
         blockContents[1].stateUpdates[1],
         stateProof.stateTreeInclusionProof,

--- a/packages/core/test/app/block-production/merkle-interval-tree.spec.ts
+++ b/packages/core/test/app/block-production/merkle-interval-tree.spec.ts
@@ -8,11 +8,8 @@ import BigNum = require('bn.js')
 /* Internal Imports */
 import {
     AbiStateUpdate, AbiStateObject, AbiRange,
+    MerkleIntervalTree, MerkleIntervalTreeNode, MerkleStateIntervalTree, PlasmaBlock
   }  from '../../../src/app/'
-import {
-  MerkleIntervalTree, MerkleIntervalTreeNode
-  // MerkleIntervalTree, MerkleStateIntervalTree, PlasmaBlock, MerkleIntervalTreeNode
-} from '../../../src/app/'
 
 import { AssertionError } from 'assert'
 
@@ -58,8 +55,6 @@ describe.only('merkle-index-tree', () => {
       const IntervalTree = new MerkleIntervalTree(leaves)
       const leafPosition = 3
       const inclusionProof = IntervalTree.getInclusionProof(leafPosition)
-      console.log('tree: ', IntervalTree.levels)
-      console.log('inclusopn proof length is: ', inclusionProof.length)
       MerkleIntervalTree.verify(
         leaves[leafPosition],
         leafPosition,
@@ -68,76 +63,69 @@ describe.only('merkle-index-tree', () => {
       )
     })
   })
-//   describe('MerkleStateIntervalTree', () => {
-//     it('should generate a tree without throwing', async() => {
-//       const stateUpdates = []
-//       for (let i = 0; i < 4; i++) {
-//         const stateObject = new AbiStateObject('0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63', '0x123456')
-//         const range = new AbiRange( new BigNum(i*100), new BigNum((i+0.5)* 100) )
-//         const stateUpdate = new AbiStateUpdate(stateObject, range, new BigNum(1), '0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63')
-//         stateUpdates.push(stateUpdate)
-//       }
-//       const merkleStateIntervalTree = new MerkleStateIntervalTree(stateUpdates)
-//       log('root', merkleStateIntervalTree.root())
-//     })
-//   })
-//   describe('PlasmaBlock', () => {
-//     it('should generate a tree without throwing', async() => {
-//       const stateUpdates = []
-//       for (let i = 0; i < 4; i++) {
-//         const stateObject = new AbiStateObject('0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63', '0x123456')
-//         const range = new AbiRange( new BigNum(i*100), new BigNum((i+0.5)* 100) )
-//         const stateUpdate = new AbiStateUpdate(stateObject, range, new BigNum(1), '0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63')
-//         stateUpdates.push(stateUpdate)
-//       }
-//       const blockContents = [
-//         {
-//           address: Buffer.from('bdAd2846585129Fc98538ce21cfcED21dDDE0a63', 'hex'),
-//           stateUpdates
-//         },
-//         {
-//           address: Buffer.from('1dAd2846585129Fc98538ce21cfcED21dDDE0a63', 'hex'),
-//           stateUpdates
-//         },
-//       ]
-//       const plasmaBlock = new PlasmaBlock(blockContents)
-//       log(plasmaBlock)
-//     })
-//     it('should generate and verify a StateUpdateInclusionProof', async() => {
-//       const stateUpdates = []
-//       for (let i = 0; i < 4; i++) {
-//         const stateObject = new AbiStateObject('0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63', '0x123456')
-//         const range = new AbiRange( new BigNum(i*100), new BigNum((i+0.5)* 100) )
-//         const stateUpdate = new AbiStateUpdate(stateObject, range, new BigNum(1), '0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63')
-//         stateUpdates.push(stateUpdate)
-//       }
-//       const blockContents = [
-//         {
-//           address: Buffer.from('bdAd2846585129Fc98538ce21cfcED21dDDE0a63', 'hex'),
-//           stateUpdates
-//         },
-//         {
-//           address: Buffer.from('1dAd2846585129Fc98538ce21cfcED21dDDE0a63', 'hex'),
-//           stateUpdates
-//         },
-//       ]
-//       const plasmaBlock = new PlasmaBlock(blockContents)
-//       console.log('subtree stateLeafNode: ', plasmaBlock.subtrees[1].levels[0][1])
-//       const stateProof = (plasmaBlock.getStateUpdateInclusionProof(1, 1))
-//       console.log('subtree roothash: ', plasmaBlock.subtrees[1].root().hash)
-//       console.log('plasma block levels: ', plasmaBlock.levels)
-//       console.log('state proof: ', stateProof)
-//       console.log(
-//         'staate update verification: ', 
-//         PlasmaBlock.verifyStateUpdateInclusionProof(
-//           blockContents[1].stateUpdates[1],
-//           stateProof.stateTreeInclusionProof,
-//           1,
-//           stateProof.addressTreeInclusionProof,
-//           1,
-//           plasmaBlock.root().hash
-//         )
-//       )
-//     })
-//   })
+  describe('MerkleStateIntervalTree', () => {
+    it('should generate a tree without throwing', async() => {
+      const stateUpdates = []
+      for (let i = 0; i < 4; i++) {
+        const stateObject = new AbiStateObject('0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63', '0x123456')
+        const range = new AbiRange( new BigNum(i*100), new BigNum((i+0.5)* 100) )
+        const stateUpdate = new AbiStateUpdate(stateObject, range, new BigNum(1), '0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63')
+        stateUpdates.push(stateUpdate)
+      }
+      const merkleStateIntervalTree = new MerkleStateIntervalTree(stateUpdates)
+      log('root', merkleStateIntervalTree.root())
+    })
+  })
+  describe('PlasmaBlock', () => {
+    it('should generate a tree without throwing', async() => {
+      const stateUpdates = []
+      for (let i = 0; i < 4; i++) {
+        const stateObject = new AbiStateObject('0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63', '0x123456')
+        const range = new AbiRange( new BigNum(i*100), new BigNum((i+0.5)* 100) )
+        const stateUpdate = new AbiStateUpdate(stateObject, range, new BigNum(1), '0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63')
+        stateUpdates.push(stateUpdate)
+      }
+      const blockContents = [
+        {
+          address: Buffer.from('1dAd2846585129Fc98538ce21cfcED21dDDE0a63', 'hex'),
+          stateUpdates
+        },
+        {
+          address: Buffer.from('bdAd2846585129Fc98538ce21cfcED21dDDE0a63', 'hex'),
+          stateUpdates
+        }
+      ]
+      const plasmaBlock = new PlasmaBlock(blockContents)
+      log(plasmaBlock)
+    })
+    it('should generate and verify a StateUpdateInclusionProof', async() => {
+      const stateUpdates = []
+      for (let i = 0; i < 4; i++) {
+        const stateObject = new AbiStateObject('0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63', '0x123456')
+        const range = new AbiRange( new BigNum(i*100), new BigNum((i+0.5)* 100) )
+        const stateUpdate = new AbiStateUpdate(stateObject, range, new BigNum(1), '0xbdAd2846585129Fc98538ce21cfcED21dDDE0a63')
+        stateUpdates.push(stateUpdate)
+      }
+      const blockContents = [
+        {
+          address: Buffer.from('1dAd2846585129Fc98538ce21cfcED21dDDE0a63', 'hex'),
+          stateUpdates
+        },
+        {
+          address: Buffer.from('bdAd2846585129Fc98538ce21cfcED21dDDE0a63', 'hex'),
+          stateUpdates
+        }
+      ]
+      const plasmaBlock = new PlasmaBlock(blockContents)
+      const stateProof = (plasmaBlock.getStateUpdateInclusionProof(1, 1))
+      PlasmaBlock.verifyStateUpdateInclusionProof(
+        blockContents[1].stateUpdates[1],
+        stateProof.stateTreeInclusionProof,
+        1,
+        stateProof.addressTreeInclusionProof,
+        1,
+        plasmaBlock.root().hash
+      )
+    })
+  })
 })

--- a/packages/core/test/app/block-production/merkle-interval-tree.spec.ts
+++ b/packages/core/test/app/block-production/merkle-interval-tree.spec.ts
@@ -11,7 +11,7 @@ import {
     MerkleIntervalTree, MerkleIntervalTreeNode, MerkleStateIntervalTree, PlasmaBlock
   }  from '../../../src/app/'
 
-describe.only('merkle-index-tree', () => {
+describe('merkle-index-tree', () => {
   describe('MerkleIntervalTreeNode', () => {
     it('should concatenate index and hash after construction', async() => {
       const node = new MerkleIntervalTreeNode(Buffer.from([255]), Buffer.from([0])) 

--- a/packages/core/test/app/block-production/merkle-interval-tree.spec.ts
+++ b/packages/core/test/app/block-production/merkle-interval-tree.spec.ts
@@ -158,7 +158,7 @@ describe('merkle-index-tree', () => {
       const plasmaBlock = new PlasmaBlock(blockContents)
       log(plasmaBlock)
     })
-    it('should generate and verify a StateUpdateInclusionProof', async () => {
+    it.only('should generate and verify a StateUpdateInclusionProof', async () => {
       const stateUpdates = []
       for (let i = 0; i < 4; i++) {
         const stateObject = new AbiStateObject(


### PR DESCRIPTION
## Description
This PR adds an in-memory block generation functionality by extending the base `MerkleIntervalTree` class into `StateIntervalTree` and `PlasmaBlockTree` classes.  For now, it only does the generation in-memory.  However, I went ahead and "flattened" most of the logic that was being used for arrays (i.e. uses of `.map`, `.push` so that the transition to storage will be much easier than before.

Ultimately, I decided to push along without adding the salting functionality which we want to implement for privacy preservation during non-inclusion proofs.  I decided against it because mostly that change is just about storing the salt, and since it's in-memory for now, we can wait until we add database support to do that, and also when we are building the inclusion verification contract, since these are when it's really relevant.

Also missing are proper interfaces for the inclusion proofs; right now, we just pass the individual components of the proof to `.verify` instead of having a proper class for inclusion proofs of each type.  I think it's fine for now.

## Questions
- Is waiting to do the salt the right play?
- Do we have a directory for constants at the moment?  Did [this](https://github.com/ben-chain/pigi/blob/9d618bb0e19d8179c34f40dcd1ef8d0571c6c5c1/packages/core/src/app/block-production/state-interval-tree.ts#L5) but it feels hacky.

## Metadata
### Fixes
- Partially fixes #297 , minus salt

### Blockers
N/A

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Plasma Group Contributing Guide and Code of Conduct](https://github.com/plasma-group/pigi/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
