### PR TITLE
Removing it.only from merkle-interval-tree.spec.ts so all core tests run

### DIFF
--- a/packages/core/test/app/block-production/merkle-interval-tree.spec.ts
+++ b/packages/core/test/app/block-production/merkle-interval-tree.spec.ts
@@ -158,7 +158,7 @@ describe('merkle-index-tree', () => {
       const plasmaBlock = new PlasmaBlock(blockContents)
       log(plasmaBlock)
     })
-    it.only('should generate and verify a StateUpdateInclusionProof', async () => {
+    it('should generate and verify a StateUpdateInclusionProof', async () => {
       const stateUpdates = []
       for (let i = 0; i < 4; i++) {
         const stateObject = new AbiStateObject(


### PR DESCRIPTION
## Description
Fixing a bug where not all Core tests are run

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Plasma Group Contributing Guide and Code of Conduct](https://github.com/plasma-group/pigi/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
