### PR TITLE
Add range bucket iterator

### DIFF
--- a/packages/core/src/app/db/iterator.ts
+++ b/packages/core/src/app/db/iterator.ts
@@ -8,7 +8,15 @@ import { AbstractIterator } from 'abstract-leveldown'
 import BigNum = require('bn.js')
 
 /* Internal Imports */
-import { Iterator, IteratorOptions, K, V, KV, DB, RangeEntry } from '../../types'
+import {
+  Iterator,
+  IteratorOptions,
+  K,
+  V,
+  KV,
+  DB,
+  RangeEntry,
+} from '../../types'
 
 const defaultIteratorOptions: IteratorOptions = {
   reverse: false,
@@ -219,7 +227,6 @@ export class BaseIterator implements Iterator {
   }
 }
 
-
 /**
  * A special purpose iterator which includes a nextRange() function that returns RangeEntrys instead of simple KVs.
  * This is used by the RangeBucket class.
@@ -229,7 +236,11 @@ export class BaseRangeIterator extends BaseIterator {
    * Constructs a RangeIterator with a particular `resultToRange()` function that will transform
    * the it.next() result into a RangeEntry.
    */
-  constructor(db: DB, options: IteratorOptions = {}, readonly resultToRange: (result: KV) => RangeEntry) {
+  constructor(
+    db: DB,
+    options: IteratorOptions = {},
+    readonly resultToRange: (result: KV) => RangeEntry
+  ) {
     super(db, options)
   }
 

--- a/packages/core/src/app/db/iterator.ts
+++ b/packages/core/src/app/db/iterator.ts
@@ -249,7 +249,7 @@ export class BaseRangeIterator extends BaseIterator {
    * @returns the RangeEntry at the next key.
    */
   public async nextRange(): Promise<RangeEntry> {
-    const res = await this.next()
+    const res: KV = await this.next()
     if (typeof res.key === 'undefined') {
       return
     }

--- a/packages/core/src/app/db/iterator.ts
+++ b/packages/core/src/app/db/iterator.ts
@@ -224,7 +224,7 @@ export class BaseIterator implements Iterator {
  * A special purpose iterator which includes a nextRange() function that returns RangeEntrys instead of simple KVs.
  * This is used by the RangeBucket class.
  */
-export class RangeIterator extends BaseIterator {
+export class BaseRangeIterator extends BaseIterator {
   /**
    * Constructs a RangeIterator with a particular `resultToRange()` function that will transform
    * the it.next() result into a RangeEntry.

--- a/packages/core/src/app/db/iterator.ts
+++ b/packages/core/src/app/db/iterator.ts
@@ -5,9 +5,10 @@
 
 /* External Imports */
 import { AbstractIterator } from 'abstract-leveldown'
+import BigNum = require('bn.js')
 
 /* Internal Imports */
-import { Iterator, IteratorOptions, K, V, KV, DB } from '../../types'
+import { Iterator, IteratorOptions, K, V, KV, DB, RangeEntry } from '../../types'
 
 const defaultIteratorOptions: IteratorOptions = {
   reverse: false,
@@ -215,5 +216,32 @@ export class BaseIterator implements Iterator {
    */
   private removePrefix(value: Buffer): Buffer {
     return value ? value.slice(this.prefix.length) : value
+  }
+}
+
+
+/**
+ * A special purpose iterator which includes a nextRange() function that returns RangeEntrys instead of simple KVs.
+ * This is used by the RangeBucket class.
+ */
+export class RangeIterator extends BaseIterator {
+  /**
+   * Constructs a RangeIterator with a particular `resultToRange()` function that will transform
+   * the it.next() result into a RangeEntry.
+   */
+  constructor(db: DB, options: IteratorOptions = {}, readonly resultToRange: (result: KV) => RangeEntry) {
+    super(db, options)
+  }
+
+  /**
+   * Advances the iterator to the next key and converts its result into a RangeEntry.
+   * @returns the RangeEntry at the next key.
+   */
+  public async nextRange(): Promise<RangeEntry> {
+    const res = await this.next()
+    if (typeof res.key === 'undefined') {
+      return
+    }
+    return this.resultToRange(res)
   }
 }

--- a/packages/core/src/app/db/range-bucket.ts
+++ b/packages/core/src/app/db/range-bucket.ts
@@ -15,15 +15,17 @@ import {
   Iterator,
   K,
   V,
+  KV,
   RangeBucket,
   RangeEntry,
   Endianness,
 } from '../../types'
-import { bufferUtils, intersects, BaseDB } from '../../app'
+import { bufferUtils, intersects, BaseDB, RangeIterator } from '../../app'
 
 /* Logging */
 import debug from 'debug'
 const log = debug('info:range-db')
+
 
 /**
  * Simple bucket implementation that forwards all
@@ -133,7 +135,7 @@ export class BaseRangeBucket implements RangeBucket {
    * @param result The resulting value which has been extracted from our DB.
    * @returns a range object with {start, end, value}
    */
-  private resultToRange(result): RangeEntry {
+  private resultToRange(result: KV): RangeEntry {
     // Helper function which gets the start and end position from a DB seek result
     return {
       start: new BigNum(this.getStartFromValue(result.value)),
@@ -280,6 +282,19 @@ export class BaseRangeBucket implements RangeBucket {
     await it.end()
     // Return the ranges
     return ranges
+  }
+
+  /**
+   * Creates an iterator with some options.
+   * @param options Parameters for the iterator.
+   * @returns the iterator instance.
+   */
+  public iterator(options?: IteratorOptions): RangeIterator {
+    const rangeIterator = new RangeIterator(this.db, {
+      ...options,
+      prefix: this.addPrefix(this.prefix),
+    }, (res: KV) => this.resultToRange(res))
+    return rangeIterator
   }
 
   /**

--- a/packages/core/src/app/db/range-bucket.ts
+++ b/packages/core/src/app/db/range-bucket.ts
@@ -18,9 +18,10 @@ import {
   KV,
   RangeBucket,
   RangeEntry,
+  RangeIterator,
   Endianness,
 } from '../../types'
-import { bufferUtils, intersects, BaseDB, RangeIterator } from '../../app'
+import { bufferUtils, intersects, BaseDB, BaseRangeIterator } from '../../app'
 
 /* Logging */
 import debug from 'debug'
@@ -290,7 +291,7 @@ export class BaseRangeBucket implements RangeBucket {
    * @returns the iterator instance.
    */
   public iterator(options?: IteratorOptions): RangeIterator {
-    const rangeIterator = new RangeIterator(this.db, {
+    const rangeIterator = new BaseRangeIterator(this.db, {
       ...options,
       prefix: this.addPrefix(this.prefix),
     }, (res: KV) => this.resultToRange(res))

--- a/packages/core/src/app/db/range-bucket.ts
+++ b/packages/core/src/app/db/range-bucket.ts
@@ -27,7 +27,6 @@ import { bufferUtils, intersects, BaseDB, BaseRangeIterator } from '../../app'
 import debug from 'debug'
 const log = debug('info:range-db')
 
-
 /**
  * Simple bucket implementation that forwards all
  * calls up to the database but appends a prefix.
@@ -291,10 +290,14 @@ export class BaseRangeBucket implements RangeBucket {
    * @returns the iterator instance.
    */
   public iterator(options?: IteratorOptions): RangeIterator {
-    const rangeIterator = new BaseRangeIterator(this.db, {
-      ...options,
-      prefix: this.addPrefix(this.prefix),
-    }, (res: KV) => this.resultToRange(res))
+    const rangeIterator = new BaseRangeIterator(
+      this.db,
+      {
+        ...options,
+        prefix: this.addPrefix(this.prefix),
+      },
+      (res: KV) => this.resultToRange(res)
+    )
     return rangeIterator
   }
 

--- a/packages/core/src/app/db/range-bucket.ts
+++ b/packages/core/src/app/db/range-bucket.ts
@@ -47,12 +47,14 @@ export class BaseRangeBucket implements RangeBucket {
   ) {}
 
   /**
-   * Adds this RangeBucket's prefix to the target Buffer
-   * @param target A Buffer which will have the prefix prepended to it.
-   * @returns resulting Buffer `prefix+target`.
+   * Concatenates some value to this bucket's prefix.
+   * @param value Value to concatenate.
+   * @returns the value concatenated to the prefix.
    */
-  private addPrefix(target: Buffer): Buffer {
-    return Buffer.concat([this.prefix, target])
+  private addPrefix(value: Buffer): Buffer {
+    return value !== undefined
+      ? Buffer.concat([this.prefix, value])
+      : this.prefix
   }
 
   /**
@@ -289,12 +291,12 @@ export class BaseRangeBucket implements RangeBucket {
    * @param options Parameters for the iterator.
    * @returns the iterator instance.
    */
-  public iterator(options?: IteratorOptions): RangeIterator {
+  public iterator(options: IteratorOptions = {}): RangeIterator {
     const rangeIterator = new BaseRangeIterator(
       this.db,
       {
         ...options,
-        prefix: this.addPrefix(this.prefix),
+        prefix: this.addPrefix(options.prefix),
       },
       (res: KV) => this.resultToRange(res)
     )

--- a/packages/core/src/types/db/db.interface.ts
+++ b/packages/core/src/types/db/db.interface.ts
@@ -6,7 +6,7 @@ import {
 } from 'abstract-leveldown'
 
 /* Internal Imports */
-import { RangeBucket } from '../../types'
+import { RangeBucket, RangeEntry } from '../../types'
 
 export type K = NonNullable<Buffer>
 export type V = NonNullable<Buffer>
@@ -178,4 +178,8 @@ export interface Iterator {
    * Ends iteration and frees resources.
    */
   end(): Promise<void>
+}
+
+export interface RangeIterator extends Iterator {
+  nextRange(): Promise<RangeEntry>
 }

--- a/packages/core/src/types/db/range-db.interface.ts
+++ b/packages/core/src/types/db/range-db.interface.ts
@@ -4,7 +4,13 @@ import BigNum = require('bn.js')
 import level from 'level'
 
 /* Internal Imports */
-import { KeyValueStore, V, Bucket, RangeIterator, IteratorOptions } from './db.interface'
+import {
+  KeyValueStore,
+  V,
+  Bucket,
+  RangeIterator,
+  IteratorOptions,
+} from './db.interface'
 
 /**
  * Represents a range of values. Note start & end are big numbers!

--- a/packages/core/src/types/db/range-db.interface.ts
+++ b/packages/core/src/types/db/range-db.interface.ts
@@ -4,7 +4,7 @@ import BigNum = require('bn.js')
 import level from 'level'
 
 /* Internal Imports */
-import { KeyValueStore, V, Bucket } from './db.interface'
+import { KeyValueStore, V, Bucket, Iterator, IteratorOptions } from './db.interface'
 
 /**
  * Represents a range of values. Note start & end are big numbers!
@@ -49,6 +49,13 @@ export interface RangeStore {
    * @returns all of the ranges which have been deleted.
    */
   del(start: BigNum, end: BigNum): Promise<RangeEntry[]>
+
+  /**
+   * Creates an iterator with some options.
+   * @param options Parameters for the iterator.
+   * @returns the iterator instance.
+   */
+  iterator(options?: IteratorOptions): Iterator
 }
 
 export interface RangeBucket extends RangeStore {

--- a/packages/core/src/types/db/range-db.interface.ts
+++ b/packages/core/src/types/db/range-db.interface.ts
@@ -4,7 +4,7 @@ import BigNum = require('bn.js')
 import level from 'level'
 
 /* Internal Imports */
-import { KeyValueStore, V, Bucket, Iterator, IteratorOptions } from './db.interface'
+import { KeyValueStore, V, Bucket, RangeIterator, IteratorOptions } from './db.interface'
 
 /**
  * Represents a range of values. Note start & end are big numbers!
@@ -55,7 +55,7 @@ export interface RangeStore {
    * @param options Parameters for the iterator.
    * @returns the iterator instance.
    */
-  iterator(options?: IteratorOptions): Iterator
+  iterator(options?: IteratorOptions): RangeIterator
 }
 
 export interface RangeBucket extends RangeStore {

--- a/packages/core/test/app/db/range-bucket.spec.ts
+++ b/packages/core/test/app/db/range-bucket.spec.ts
@@ -60,7 +60,7 @@ const testPutResults = async (
 
 const putRanges = async (
   db: RangeBucket,
-  putContents: any[],
+  putContents: any[]
 ): Promise<void> => {
   for (const putContent of putContents) {
     await db.put(
@@ -71,10 +71,7 @@ const putRanges = async (
   }
 }
 
-const compareResult = (
-  res: any,
-  expectedResult: any
-): void => {
+const compareResult = (res: any, expectedResult: any): void => {
   const strResult = new StringRangeEntry(res)
   strResult.stringRangeEntry.should.deep.equal(expectedResult)
 }
@@ -285,7 +282,7 @@ describe('RangeDB', () => {
           { start: '0', end: '50', value: 'x4' },
           { start: '50', end: '150', value: 'z4' },
           { start: '150', end: '200', value: 'y4' },
-        ]
+        ],
       }
 
       // Put our ranges

--- a/packages/core/test/app/db/range-bucket.spec.ts
+++ b/packages/core/test/app/db/range-bucket.spec.ts
@@ -274,14 +274,14 @@ describe('RangeDB', () => {
     it('allows nextRange() to be called by the iterator returning a RangeEntry instead of a KV', async () => {
       const testRanges = {
         inputs: [
-          { start: '0', end: '100', value: 'x4' },
-          { start: '100', end: '200', value: 'y4' },
-          { start: '50', end: '150', value: 'z4' },
+          { start: '0', end: '100', value: 'x' },
+          { start: '100', end: '200', value: 'y' },
+          { start: '200', end: '225', value: 'z' },
         ],
         expectedResults: [
-          { start: '0', end: '50', value: 'x4' },
-          { start: '50', end: '150', value: 'z4' },
-          { start: '150', end: '200', value: 'y4' },
+          { start: '0', end: '100', value: 'x' },
+          { start: '100', end: '200', value: 'y' },
+          { start: '200', end: '225', value: 'z' },
         ],
       }
 


### PR DESCRIPTION
## Description
This adds an `iterator()` function to the RangeBucket. This iterator is a bit custom because it has a function `nextRange()` which instead of returning a raw KV result, it instead parses it and returns a `RangeEntry`.

This feature is particularly useful if we ever want to iterate over the full contents of a RangeDB and return proper `RangeEntries`. I needed this for the way I was going to build the merkle tree creator using LevelDB. However, realized that our blocks won't get large enough to need to use a DB like this and so have abandoned that. Still this could be a useful feature!

## Questions
- Yall know of any cleaner ways to return this iterator other than extending our BaseIterator class?
- Should we make `next()` return a Range by default instead of calling it `nextRange()`? And maybe add `nextRaw()` which acts like the normal next function?

## Metadata
### Fixes
- Fixes #318


## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Plasma Group Contributing Guide and Code of Conduct](https://github.com/plasma-group/pigi/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
