### PR TITLE
Feat/399/fix state channel exit claim

### DIFF
--- a/packages/core/src/app/ovm/deciders/examples/utils.ts
+++ b/packages/core/src/app/ovm/deciders/examples/utils.ts
@@ -17,7 +17,7 @@ export class Utils {
     return (
       !!message &&
       !!other &&
-      message.message.channelId.equals(other.message.channelId) &&
+      message.message.channelID.equals(other.message.channelID) &&
       message.message.nonce.equals(other.message.nonce) &&
       (message.sender.equals(other.sender) ||
         message.sender.equals(other.recipient)) &&

--- a/packages/core/src/app/ovm/quantifiers/signed-by-quantifier.ts
+++ b/packages/core/src/app/ovm/quantifiers/signed-by-quantifier.ts
@@ -1,8 +1,11 @@
 import { Quantifier, QuantifierResult } from '../../../types/ovm'
 import { SignedByDBInterface } from '../../../types/ovm/db/signed-by-db.interface'
+import { deserializeBuffer, deserializeMessage } from '../../serialization'
+import { Message } from '../../../types/serialization'
 
 interface SignedByQuantifierParameters {
   address: Buffer
+  channelID?: Buffer
 }
 
 /*
@@ -22,9 +25,18 @@ export class SignedByQuantifier implements Quantifier {
   public async getAllQuantified(
     signerParams: SignedByQuantifierParameters
   ): Promise<QuantifierResult> {
-    const messages: Buffer[] = await this.db.getAllSignedBy(
-      signerParams.address
-    )
+    let messages: Buffer[] = await this.db.getAllSignedBy(signerParams.address)
+
+    if ('channelID' in signerParams && signerParams['channelID']) {
+      messages = messages.filter((m) => {
+        try {
+          const message: Message = deserializeBuffer(m, deserializeMessage)
+          return signerParams.channelID.equals(message.channelId)
+        } catch (e) {
+          return false
+        }
+      })
+    }
 
     return {
       results: messages,

--- a/packages/core/src/app/ovm/quantifiers/signed-by-quantifier.ts
+++ b/packages/core/src/app/ovm/quantifiers/signed-by-quantifier.ts
@@ -31,7 +31,7 @@ export class SignedByQuantifier implements Quantifier {
       messages = messages.filter((m) => {
         try {
           const message: Message = deserializeBuffer(m, deserializeMessage)
-          return signerParams.channelID.equals(message.channelId)
+          return signerParams.channelID.equals(message.channelID)
         } catch (e) {
           return false
         }

--- a/packages/core/src/app/serialization/serializers.ts
+++ b/packages/core/src/app/serialization/serializers.ts
@@ -87,7 +87,7 @@ export const deserializeBuffer = (
  */
 export const deserializeMessage = (
   message: string,
-  dataDeserializer: (string) => {}
+  dataDeserializer: (string) => {} = (d) => d
 ): Message => {
   const parsedObject = deserializeObject(message)
   return {

--- a/packages/core/src/app/serialization/serializers.ts
+++ b/packages/core/src/app/serialization/serializers.ts
@@ -53,10 +53,10 @@ export const stateChannelMessageToString = (
  */
 export const messageToBuffer = (
   message: Message,
-  messageSerializer: ({}) => string
+  messageSerializer: ({}) => string = (_) => '{}'
 ): Buffer => {
   return objectToBuffer({
-    channelId: message.channelId.toString(),
+    channelID: message.channelID.toString(),
     nonce: message.nonce,
     data: messageSerializer(message.data),
   })
@@ -91,7 +91,7 @@ export const deserializeMessage = (
 ): Message => {
   const parsedObject = deserializeObject(message)
   return {
-    channelId: Buffer.from(parsedObject['channelId']),
+    channelID: Buffer.from(parsedObject['channelID']),
     nonce:
       'nonce' in parsedObject
         ? new BigNumber(parsedObject['nonce'])

--- a/packages/core/src/types/ovm/db/message-db.interface.ts
+++ b/packages/core/src/types/ovm/db/message-db.interface.ts
@@ -20,24 +20,24 @@ export interface MessageDB {
    * Gets the ParsedMessage sent by the counterparty that has the same channelID and nonce
    * but different data than the one that created locally and stored, if one exists.
    *
-   * @param channelId the channel ID in question
+   * @param channelID the channel ID in question
    * @param nonce the nonce in question
    * @returns The message, if there is one
    */
   getConflictingCounterpartyMessage(
-    channelId: Buffer,
+    channelID: Buffer,
     nonce: BigNumber
   ): Promise<ParsedMessage>
 
   /**
    * Gets a specific message by the provided channel ID and nonce.
    *
-   * @param channelId the channel ID in question
+   * @param channelID the channel ID in question
    * @param nonce the nonce in question
    * @returns The message, if there is one
    */
   getMessageByChannelIdAndNonce(
-    channelId: Buffer,
+    channelID: Buffer,
     nonce: BigNumber
   ): Promise<ParsedMessage>
 
@@ -45,13 +45,13 @@ export interface MessageDB {
    * Gets all messages signed by the provided signer address.
    *
    * @param signer the signer address to filter by
-   * @param channelId an optional channelId to filter by
+   * @param channelID an optional channelID to filter by
    * @param nonce an optional nonce to filter by
    * @returns the list of ParsedMessages that match the provided filters
    */
   getMessagesSignedBy(
     signer: Buffer,
-    channelId?: Buffer,
+    channelID?: Buffer,
     nonce?: BigNumber
   ): Promise<ParsedMessage[]>
 
@@ -59,13 +59,13 @@ export interface MessageDB {
    * Gets all messages by the provided sender address.
    *
    * @param sender the sender address to filter by
-   * @param channelId an optional channelId to filter by
+   * @param channelID an optional channelID to filter by
    * @param nonce an optional nonce to filter by
    * @returns the list of ParsedMessages that match the provided filters
    */
   getMessagesBySender(
     sender: Buffer,
-    channelId?: Buffer,
+    channelID?: Buffer,
     nonce?: BigNumber
   ): Promise<ParsedMessage[]>
 
@@ -73,13 +73,13 @@ export interface MessageDB {
    * Gets all messages by the provided recipient address.
    *
    * @param recipient the recipient address to filter by
-   * @param channelId an optional channelId to filter by
+   * @param channelID an optional channelID to filter by
    * @param nonce an optional nonce to filter by
    * @returns the list of ParsedMessages that match the provided filters
    */
   getMessagesByRecipient(
     recipient: Buffer,
-    channelId?: Buffer,
+    channelID?: Buffer,
     nonce?: BigNumber
   ): Promise<ParsedMessage[]>
 }

--- a/packages/core/src/types/ovm/db/state-channel-message-db.interface.ts
+++ b/packages/core/src/types/ovm/db/state-channel-message-db.interface.ts
@@ -13,23 +13,23 @@ export interface StateChannelMessageDBInterface
    * Gets the ParsedMessage of the StateChannelMessage with the provided
    * ChannelID that is signed by both parties and has the highest nonce.
    *
-   * @param channelId The channel ID
+   * @param channelID The channel ID
    * @returns The ParsedMessage, if one exits
    */
   getMostRecentValidStateChannelMessage(
-    channelId: Buffer
+    channelID: Buffer
   ): Promise<ParsedMessage>
 
   /**
    * Gets the ParsedMessage of the StateChannelMessage with the provided
    * ChannelID that is signed by the provided address and has the highest nonce.
    *
-   * @param channelId The channel ID
+   * @param channelID The channel ID
    * @param address The signer's address
    * @returns The ParsedMessage, if one exits
    */
   getMostRecentMessageSignedBy(
-    channelId: Buffer,
+    channelID: Buffer,
     address: Buffer
   ): Promise<ParsedMessage>
 
@@ -47,17 +47,17 @@ export interface StateChannelMessageDBInterface
    * Determines whether the channel with the provided ChannelID has been
    * exited or has an active exit attempt by either party.
    *
-   * @param channelId The Channel ID in question
+   * @param channelID The Channel ID in question
    * @returns True if exited, false otherwise.
    */
-  isChannelExited(channelId: Buffer): Promise<boolean>
+  isChannelExited(channelID: Buffer): Promise<boolean>
 
   /**
    * Marks the provided Channel ID as exited.
    *
-   * @param channelId The Channel ID in question
+   * @param channelID The Channel ID in question
    */
-  markChannelExited(channelId: Buffer): Promise<void>
+  markChannelExited(channelID: Buffer): Promise<void>
 
   /**
    * Gets the ChannelID associated with the provided counterparty address.
@@ -71,8 +71,8 @@ export interface StateChannelMessageDBInterface
    * Determines whether or not the provided Channel ID represents a
    * State Channel that we are a party of.
    *
-   * @param channelId The Channel ID in question
+   * @param channelID The Channel ID in question
    * @returns True if so, false otherwise
    */
-  channelIdExists(channelId: Buffer): Promise<boolean>
+  channelIDExists(channelID: Buffer): Promise<boolean>
 }

--- a/packages/core/src/types/serialization/message.interface.ts
+++ b/packages/core/src/types/serialization/message.interface.ts
@@ -6,7 +6,7 @@ export interface SignedMessage {
 }
 
 export interface Message {
-  channelId: Buffer
+  channelID: Buffer
   nonce?: BigNumber
   data: {}
 }

--- a/packages/core/test/app/ovm/deciders/hash-preimage-existence-decider.spec.ts
+++ b/packages/core/test/app/ovm/deciders/hash-preimage-existence-decider.spec.ts
@@ -71,7 +71,7 @@ describe('HashPreimageExistenceDecider', () => {
 
     it('should decide true for valid preimage from Message', async () => {
       await preimageDB.handleMessage({
-        channelId: Buffer.from('chan'),
+        channelID: Buffer.from('chan'),
         data: { preimage },
       })
       const decision: Decision = await decider.decide({ hash })

--- a/packages/core/test/app/ovm/examples/simple-state-channel.spec.ts
+++ b/packages/core/test/app/ovm/examples/simple-state-channel.spec.ts
@@ -781,7 +781,7 @@ describe('State Channel Tests', () => {
               decider: ForAllSuchThatDecider.instance(),
               input: {
                 quantifier: bSignedByQuantifier,
-                quantifierParameters: { address: aAddress },
+                quantifierParameters: { address: aAddress, channelID: mostRecentMessage.message.channelId },
                 propertyFactory: (message: Buffer) => {
                   return {
                     decider: MessageNonceLessThanDecider.instance(),
@@ -863,7 +863,7 @@ describe('State Channel Tests', () => {
           input: {
             // Claim that A has signed the message to be exited (this will evaluate to true)
             left: {
-              decider: bSignedByDecider,
+              decider: aSignedByDecider,
               input: {
                 message: messageToBuffer(
                   mostRecentMessage.message,
@@ -879,8 +879,8 @@ describe('State Channel Tests', () => {
             right: {
               decider: ForAllSuchThatDecider.instance(),
               input: {
-                quantifier: bSignedByQuantifier,
-                quantifierParameters: { address: bAddress },
+                quantifier: aSignedByQuantifier,
+                quantifierParameters: { address: bAddress, channelID: mostRecentMessage.message.channelId },
                 propertyFactory: (message: Buffer) => {
                   return {
                     decider: MessageNonceLessThanDecider.instance(),

--- a/packages/core/test/app/ovm/examples/simple-state-channel.spec.ts
+++ b/packages/core/test/app/ovm/examples/simple-state-channel.spec.ts
@@ -85,7 +85,7 @@ class TestStateChannelMessageDB implements StateChannelMessageDBInterface {
 
     // Check if conflict, and if so, store separately
     const potentialConflict: ParsedMessage = await this.getMessageByChannelIdAndNonce(
-      parsedMessage.message.channelId,
+      parsedMessage.message.channelID,
       parsedMessage.message.nonce
     )
 
@@ -94,13 +94,13 @@ class TestStateChannelMessageDB implements StateChannelMessageDBInterface {
       return
     }
 
-    const channelId: Buffer = await this.getChannelForCounterparty(
+    const channelID: Buffer = await this.getChannelForCounterparty(
       parsedMessage.sender.equals(this.myAddress)
         ? parsedMessage.recipient
         : parsedMessage.sender
     )
 
-    if (channelId && !channelId.equals(parsedMessage.message.channelId)) {
+    if (channelID && !channelID.equals(parsedMessage.message.channelID)) {
       throw Error(
         'Cannot store message because at least one participant is not a part of the listed channel.'
       )
@@ -109,7 +109,7 @@ class TestStateChannelMessageDB implements StateChannelMessageDBInterface {
     for (let i = 0; i < this.messageStore.length; i++) {
       const parsedMsg: ParsedMessage = this.messageStore[i]
       if (
-        parsedMsg.message.channelId.equals(parsedMessage.message.channelId) &&
+        parsedMsg.message.channelID.equals(parsedMessage.message.channelID) &&
         objectsEqual(parsedMsg.message, parsedMessage.message) &&
         ((!parsedMsg.message.nonce && !parsedMessage.message.nonce) ||
           (parsedMsg.message.nonce &&
@@ -125,12 +125,12 @@ class TestStateChannelMessageDB implements StateChannelMessageDBInterface {
   }
 
   public async getMessageByChannelIdAndNonce(
-    channelId: Buffer,
+    channelID: Buffer,
     nonce: BigNumber
   ): Promise<ParsedMessage> {
     for (const parsedMsg of this.messageStore) {
       if (
-        parsedMsg.message.channelId.equals(channelId) &&
+        parsedMsg.message.channelID.equals(channelID) &&
         parsedMsg.message.nonce &&
         parsedMsg.message.nonce.eq(nonce)
       ) {
@@ -142,7 +142,7 @@ class TestStateChannelMessageDB implements StateChannelMessageDBInterface {
 
   public async getMessagesByRecipient(
     recipient: Buffer,
-    channelId?: Buffer,
+    channelID?: Buffer,
     nonce?: BigNumber
   ): Promise<ParsedMessage[]> {
     // passes back live references to messages, but that doesn't matter for these tests.
@@ -150,7 +150,7 @@ class TestStateChannelMessageDB implements StateChannelMessageDBInterface {
     for (const parsedMsg of this.messageStore) {
       if (
         parsedMsg.recipient.equals(recipient) &&
-        (!channelId || parsedMsg.message.channelId.equals(channelId)) &&
+        (!channelID || parsedMsg.message.channelID.equals(channelID)) &&
         (!nonce ||
           (parsedMsg.message.nonce && parsedMsg.message.nonce.eq(nonce)))
       ) {
@@ -163,7 +163,7 @@ class TestStateChannelMessageDB implements StateChannelMessageDBInterface {
 
   public async getMessagesBySender(
     sender: Buffer,
-    channelId?: Buffer,
+    channelID?: Buffer,
     nonce?: BigNumber
   ): Promise<ParsedMessage[]> {
     // passes back live references to messages, but that doesn't matter for these tests.
@@ -171,7 +171,7 @@ class TestStateChannelMessageDB implements StateChannelMessageDBInterface {
     for (const msg of this.messageStore) {
       if (
         msg.sender.equals(sender) &&
-        (!channelId || msg.message.channelId.equals(channelId)) &&
+        (!channelID || msg.message.channelID.equals(channelID)) &&
         (!nonce || (msg.message.nonce && msg.message.nonce.eq(nonce)))
       ) {
         messages.push(msg)
@@ -183,7 +183,7 @@ class TestStateChannelMessageDB implements StateChannelMessageDBInterface {
 
   public async getMessagesSignedBy(
     signer: Buffer,
-    channelId?: Buffer,
+    channelID?: Buffer,
     nonce?: BigNumber
   ): Promise<ParsedMessage[]> {
     // passes back live references to messages, but that doesn't matter for these tests.
@@ -191,7 +191,7 @@ class TestStateChannelMessageDB implements StateChannelMessageDBInterface {
     for (const parsedMsg of this.messageStore) {
       if (
         TestStateChannelMessageDB.messageSignedBy(parsedMsg, signer) &&
-        (!channelId || parsedMsg.message.channelId.equals(channelId)) &&
+        (!channelID || parsedMsg.message.channelID.equals(channelID)) &&
         (!nonce ||
           (parsedMsg.message.nonce && parsedMsg.message.nonce.eq(nonce)))
       ) {
@@ -242,15 +242,15 @@ class TestStateChannelMessageDB implements StateChannelMessageDBInterface {
   }
 
   public async getConflictingCounterpartyMessage(
-    channelId: Buffer,
+    channelID: Buffer,
     nonce: BigNumber
   ): Promise<ParsedMessage> {
-    return this.getConflict(channelId, nonce)
+    return this.getConflict(channelID, nonce)
   }
 
-  public async channelIdExists(channelId: Buffer): Promise<boolean> {
+  public async channelIDExists(channelID: Buffer): Promise<boolean> {
     for (const message of this.messageStore) {
-      if (channelId.equals(message.message.channelId)) {
+      if (channelID.equals(message.message.channelID)) {
         return true
       }
     }
@@ -261,7 +261,7 @@ class TestStateChannelMessageDB implements StateChannelMessageDBInterface {
     message: ParsedMessage
   ): Promise<ParsedMessage> {
     const conflict: ParsedMessage = this.getConflict(
-      message.message.channelId,
+      message.message.channelID,
       message.message.nonce
     )
     if (!!conflict) {
@@ -270,7 +270,7 @@ class TestStateChannelMessageDB implements StateChannelMessageDBInterface {
 
     for (const msg of this.messageStore) {
       const storedConflict = this.getConflict(
-        msg.message.channelId,
+        msg.message.channelID,
         msg.message.nonce
       )
       if (
@@ -285,20 +285,20 @@ class TestStateChannelMessageDB implements StateChannelMessageDBInterface {
   public async getChannelForCounterparty(address: Buffer): Promise<Buffer> {
     for (const message of this.messageStore) {
       if (message.recipient.equals(address) || message.sender.equals(address)) {
-        return message.message.channelId
+        return message.message.channelID
       }
     }
   }
 
   public async getMostRecentMessageSignedBy(
-    channelId: Buffer,
+    channelID: Buffer,
     address: Buffer
   ): Promise<ParsedMessage> {
     const addressString: string = address.toString()
     let mostRecent: ParsedMessage
     for (const message of this.messageStore) {
       if (
-        message.message.channelId.equals(channelId) &&
+        message.message.channelID.equals(channelID) &&
         (!mostRecent || message.message.nonce.gt(mostRecent.message.nonce)) &&
         addressString in message.signatures
       ) {
@@ -309,12 +309,12 @@ class TestStateChannelMessageDB implements StateChannelMessageDBInterface {
   }
 
   public async getMostRecentValidStateChannelMessage(
-    channelId: Buffer
+    channelID: Buffer
   ): Promise<ParsedMessage> {
     let mostRecent: ParsedMessage
     for (const message of this.messageStore) {
       if (
-        message.message.channelId.equals(channelId) &&
+        message.message.channelID.equals(channelID) &&
         (!mostRecent || message.message.nonce.gt(mostRecent.message.nonce)) &&
         Object.keys(message.signatures).length === 2
       ) {
@@ -324,20 +324,20 @@ class TestStateChannelMessageDB implements StateChannelMessageDBInterface {
     return mostRecent
   }
 
-  public async isChannelExited(channelId: Buffer): Promise<boolean> {
-    return this.exitedChannels.has(channelId.toString())
+  public async isChannelExited(channelID: Buffer): Promise<boolean> {
+    return this.exitedChannels.has(channelID.toString())
   }
 
-  public async markChannelExited(channelId: Buffer): Promise<void> {
-    this.exitedChannels.add(channelId.toString())
+  public async markChannelExited(channelID: Buffer): Promise<void> {
+    this.exitedChannels.add(channelID.toString())
   }
 
   public getMyAddress(): Buffer {
     return this.myAddress
   }
 
-  private getConflict(channelId: Buffer, nonce: BigNumber): ParsedMessage {
-    const channelString: string = channelId.toString()
+  private getConflict(channelID: Buffer, nonce: BigNumber): ParsedMessage {
+    const channelString: string = channelID.toString()
     const nonceString: string = nonce.toString()
     if (
       channelString in this.conflictingMessageStore &&
@@ -349,7 +349,7 @@ class TestStateChannelMessageDB implements StateChannelMessageDBInterface {
   }
 
   private putConflict(message: ParsedMessage): void {
-    const channelString: string = message.message.channelId.toString()
+    const channelString: string = message.message.channelID.toString()
     const nonceString: string = message.message.nonce.toString()
     if (!(channelString in this.conflictingMessageStore)) {
       this.conflictingMessageStore[channelString] = {}
@@ -362,7 +362,7 @@ const checkSignedMessage = (
   signedMessage: SignedMessage,
   sender: Buffer,
   nonce?: BigNumber,
-  channelId?: Buffer,
+  channelID?: Buffer,
   signers?: Buffer[],
   addressBalance?: AddressBalance
 ) => {
@@ -386,14 +386,14 @@ const checkSignedMessage = (
     )
   }
 
-  if (!!channelId) {
+  if (!!channelID) {
     assert(
-      channelId.equals(parsedMessage.message.channelId),
-      `Channel ID should equal ${channelId.toString()}`
+      channelID.equals(parsedMessage.message.channelID),
+      `Channel ID should equal ${channelID.toString()}`
     )
   } else {
     assert(
-      !!parsedMessage.message.channelId,
+      !!parsedMessage.message.channelID,
       `Channel ID should exist for all messages`
     )
   }
@@ -430,7 +430,7 @@ const getChannelId = (
   myAddress: Buffer = undefined
 ): Buffer => {
   return parseStateChannelSignedMessage(signedMessage, myAddress).message
-    .channelId
+    .channelID
 }
 
 describe('State Channel Tests', () => {
@@ -528,7 +528,7 @@ describe('State Channel Tests', () => {
       counterSigned,
       myClient.myAddress,
       nonce,
-      parsedMessage.message.channelId,
+      parsedMessage.message.channelID,
       [myClient.myAddress],
       parsedMessage.message.data['addressBalance']
     )
@@ -575,7 +575,7 @@ describe('State Channel Tests', () => {
         nextMessage,
         aAddress,
         new BigNumber(2),
-        parsedMessage.message.channelId,
+        parsedMessage.message.channelID,
         [aAddress],
         parsedMessage.message.data['addressBalance']
       )
@@ -603,7 +603,7 @@ describe('State Channel Tests', () => {
         nextMessage,
         bAddress,
         new BigNumber(2),
-        parsedMessage.message.channelId,
+        parsedMessage.message.channelID,
         [bAddress],
         parsedMessage.message.data['addressBalance']
       )
@@ -631,7 +631,7 @@ describe('State Channel Tests', () => {
         nextMessage,
         aAddress,
         new BigNumber(2),
-        parsedMessage.message.channelId,
+        parsedMessage.message.channelID,
         [aAddress],
         parsedMessage.message.data['addressBalance']
       )
@@ -661,7 +661,7 @@ describe('State Channel Tests', () => {
         nextMessage,
         bAddress,
         new BigNumber(2),
-        parsedMessage.message.channelId,
+        parsedMessage.message.channelID,
         [bAddress],
         parsedMessage.message.data['addressBalance']
       )
@@ -728,7 +728,7 @@ describe('State Channel Tests', () => {
           nextMessage,
           aAddress,
           new BigNumber(2),
-          parsedMessage.message.channelId,
+          parsedMessage.message.channelID,
           [aAddress],
           parsedMessage.message.data['addressBalance']
         )
@@ -781,7 +781,10 @@ describe('State Channel Tests', () => {
               decider: ForAllSuchThatDecider.instance(),
               input: {
                 quantifier: bSignedByQuantifier,
-                quantifierParameters: { address: aAddress, channelID: mostRecentMessage.message.channelId },
+                quantifierParameters: {
+                  address: aAddress,
+                  channelID: mostRecentMessage.message.channelID,
+                },
                 propertyFactory: (message: Buffer) => {
                   return {
                     decider: MessageNonceLessThanDecider.instance(),
@@ -880,7 +883,10 @@ describe('State Channel Tests', () => {
               decider: ForAllSuchThatDecider.instance(),
               input: {
                 quantifier: aSignedByQuantifier,
-                quantifierParameters: { address: bAddress, channelID: mostRecentMessage.message.channelId },
+                quantifierParameters: {
+                  address: bAddress,
+                  channelID: mostRecentMessage.message.channelID,
+                },
                 propertyFactory: (message: Buffer) => {
                   return {
                     decider: MessageNonceLessThanDecider.instance(),


### PR DESCRIPTION
## Description
Fixes the fact that SignedByQuantifier needs to have the option to filter on ChannelID to be useful. Adds that as an optional parameter and a test around it

## Metadata
### Fixes
- Fixes #399 

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Plasma Group Contributing Guide and Code of Conduct](https://github.com/plasma-group/pigi/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
