### PR TITLE
- 

### DIFF
--- a/packages/core/src/app/ovm/deciders/examples/message-nonce-less-than-decider.ts
+++ b/packages/core/src/app/ovm/deciders/examples/message-nonce-less-than-decider.ts
@@ -21,7 +21,6 @@ export class MessageNonceLessThanDecider implements Decider {
 
   public async decide(
     input: MessageNonceLessThanInput,
-    witness: undefined,
     noCache?: boolean
   ): Promise<Decision> {
     const justification: ImplicationProofItem[] = [
@@ -30,7 +29,7 @@ export class MessageNonceLessThanDecider implements Decider {
           decider: this,
           input,
         },
-        implicationWitness: witness,
+        implicationWitness: undefined,
       },
     ]
 

--- a/packages/core/src/app/ovm/deciders/for-all-such-that-decider.ts
+++ b/packages/core/src/app/ovm/deciders/for-all-such-that-decider.ts
@@ -14,7 +14,6 @@ export interface ForAllSuchThatInput {
   quantifier: Quantifier
   quantifierParameters: any
   propertyFactory: PropertyFactory
-  witnessFactory?: WitnessFactory | undefined
 }
 
 /**
@@ -32,7 +31,6 @@ export class ForAllSuchThatDecider implements Decider {
 
   public async decide(
     input: ForAllSuchThatInput,
-    _witness?: undefined,
     noCache?: boolean
   ): Promise<Decision> {
     const quantifierResult: QuantifierResult = await input.quantifier.getAllQuantified(
@@ -44,13 +42,9 @@ export class ForAllSuchThatDecider implements Decider {
     const trueDecisions: Decision[] = []
     for (const res of quantifierResult.results) {
       const prop: Property = input.propertyFactory(res)
-      const witness: any = !!input.witnessFactory
-        ? input.witnessFactory(res)
-        : undefined
       try {
         const decision: Decision = await prop.decider.decide(
           prop.input,
-          witness,
           noCache
         )
         if (!decision.outcome) {

--- a/packages/core/src/app/ovm/deciders/hash-preimage-existence-decider.ts
+++ b/packages/core/src/app/ovm/deciders/hash-preimage-existence-decider.ts
@@ -15,11 +15,7 @@ export class HashPreimageExistenceDecider implements Decider {
     private readonly hashAlgorithm: HashAlgorithm
   ) {}
 
-  public async decide(
-    input: HashInput,
-    _witness?: undefined,
-    _noCache?: boolean
-  ): Promise<Decision> {
+  public async decide(input: HashInput, _noCache?: boolean): Promise<Decision> {
     const preimage: Buffer = await this.db.getPreimage(
       input.hash,
       this.hashAlgorithm

--- a/packages/core/src/app/ovm/deciders/not-decider.ts
+++ b/packages/core/src/app/ovm/deciders/not-decider.ts
@@ -7,7 +7,6 @@ import {
 
 export interface NotDeciderInput {
   property: Property
-  witness: any
 }
 
 /**
@@ -16,12 +15,10 @@ export interface NotDeciderInput {
 export class NotDecider implements Decider {
   public async decide(
     input: NotDeciderInput,
-    witness?: undefined,
     noCache?: boolean
   ): Promise<Decision> {
     const decision: Decision = await input.property.decider.decide(
       input.property.input,
-      input.witness,
       noCache
     )
 

--- a/packages/core/src/app/ovm/deciders/or-decider.ts
+++ b/packages/core/src/app/ovm/deciders/or-decider.ts
@@ -8,7 +8,6 @@ import { CannotDecideError, handleCannotDecideError } from './utils'
 
 export interface OrDeciderInput {
   properties: Property[]
-  witnesses: any[]
 }
 
 /**
@@ -26,13 +25,12 @@ export class OrDecider implements Decider {
 
   public async decide(
     input: OrDeciderInput,
-    witness?: undefined,
     noCache?: boolean
   ): Promise<Decision> {
     const decisions: Decision[] = await Promise.all(
       input.properties.map((property: Property, index: number) =>
         property.decider
-          .decide(property.input, input.witnesses[index], noCache)
+          .decide(property.input, noCache)
           .catch(handleCannotDecideError)
       )
     )
@@ -74,7 +72,7 @@ export class OrDecider implements Decider {
    * returns true if any of the sub-Decisions returned true.
    *
    * @param input The input that led to the Decision
-   * @param subDecision The decision of the wrapped Property, provided the witness
+   * @param subDecision The decision of the wrapped Property
    * @returns The Decision
    */
   private getDecision(input: OrDeciderInput, subDecision: Decision): Decision {

--- a/packages/core/src/app/ovm/deciders/signed-by-decider.ts
+++ b/packages/core/src/app/ovm/deciders/signed-by-decider.ts
@@ -17,11 +17,7 @@ export class SignedByDecider implements Decider {
     private readonly myAddress: Buffer
   ) {}
 
-  public async decide(
-    input: any,
-    _witness?: undefined,
-    _noCache?: boolean
-  ): Promise<Decision> {
+  public async decide(input: any, _noCache?: boolean): Promise<Decision> {
     const signature: Buffer = await this.signedByDb.getMessageSignature(
       input.message,
       input.publicKey
@@ -29,7 +25,7 @@ export class SignedByDecider implements Decider {
 
     if (!signature && !input.publicKey.equals(this.myAddress)) {
       throw new CannotDecideError(
-        'Signature does not match the provided witness, but we do not know for certain that the message was not signed by the private key associated with the provided public key.'
+        'We do not have a signature for this public key and message, but we do not know for certain that the message was not signed by the private key associated with the provided public key.'
       )
     }
 

--- a/packages/core/src/app/ovm/deciders/there-exists-such-that-decider.ts
+++ b/packages/core/src/app/ovm/deciders/there-exists-such-that-decider.ts
@@ -14,7 +14,6 @@ export interface ThereExistsSuchThatInput {
   quantifier: Quantifier
   quantifierParameters: any
   propertyFactory: PropertyFactory
-  witnessFactory: WitnessFactory | undefined
 }
 
 /**
@@ -24,7 +23,6 @@ export interface ThereExistsSuchThatInput {
 export class ThereExistsSuchThatDecider implements Decider {
   public async decide(
     input: ThereExistsSuchThatInput,
-    _witness?: undefined,
     noCache?: boolean
   ): Promise<Decision> {
     const quantifierResult: QuantifierResult = await input.quantifier.getAllQuantified(
@@ -36,13 +34,9 @@ export class ThereExistsSuchThatDecider implements Decider {
     const falseDecisions: Decision[] = []
     for (const res of quantifierResult.results) {
       const prop: Property = input.propertyFactory(res)
-      const witness: any = !!input.witnessFactory
-        ? input.witnessFactory(res)
-        : undefined
       try {
         const decision: Decision = await prop.decider.decide(
           prop.input,
-          witness,
           noCache
         )
         if (decision.outcome) {

--- a/packages/core/src/app/ovm/examples/state-channel-client.ts
+++ b/packages/core/src/app/ovm/examples/state-channel-client.ts
@@ -131,38 +131,41 @@ export class StateChannelClient {
     return {
       decider: AndDecider.instance(),
       input: {
-        left: {
-          decider: this.signedByDecider,
-          input: {
-            message: messageToBuffer(
-              mostRecent.message,
-              stateChannelMessageToString
-            ),
-            publicKey: counterparty,
-          },
-        },
-        leftWitness: undefined,
-        right: {
-          decider: ForAllSuchThatDecider.instance(),
-          input: {
-            quantifier: this.signedByQuantifier,
-            quantifierParameters: { address: this.myAddress },
-            propertyFactory: (signedMessage: Buffer) => {
-              return {
-                decider: MessageNonceLessThanDecider.instance(),
-                input: {
-                  messageWithNonce: deserializeBuffer(
-                    signedMessage,
-                    deserializeMessage,
-                    stateChannelMessageDeserializer
-                  ),
-                  lessThanThis: mostRecent.message.nonce.add(ONE),
-                },
-              }
+        properties: [
+          {
+            decider: this.signedByDecider,
+            input: {
+              message: messageToBuffer(
+                mostRecent.message,
+                stateChannelMessageToString
+              ),
+              publicKey: counterparty,
+            },
+            witness: {
+              signature: mostRecent.signatures[counterparty.toString()],
             },
           },
-        },
-        rightWitness: undefined,
+          {
+            decider: ForAllSuchThatDecider.instance(),
+            input: {
+              quantifier: this.signedByQuantifier,
+              quantifierParameters: { address: this.myAddress },
+              propertyFactory: (signedMessage: Buffer) => {
+                return {
+                  decider: MessageNonceLessThanDecider.instance(),
+                  input: {
+                    messageWithNonce: deserializeBuffer(
+                      signedMessage,
+                      deserializeMessage,
+                      stateChannelMessageDeserializer
+                    ),
+                    lessThanThis: mostRecent.message.nonce.add(ONE),
+                  },
+                }
+              },
+            },
+          },
+        ],
       },
     }
   }

--- a/packages/core/src/app/serialization/examples/simple-state-channel.ts
+++ b/packages/core/src/app/serialization/examples/simple-state-channel.ts
@@ -34,20 +34,21 @@ export type NonceLessThanPropertyFactory = (input: any) => NonceLessThanProperty
 export interface StateChannelExitClaim extends Property {
   decider: AndDecider
   input: {
-    left: {
-      decider: SignedByDecider // Asserts this message is signed by counter-party
-      input: SignedByInput
-    }
-    leftWitness: any
-    right: {
-      decider: ForAllSuchThatDecider
-      input: {
-        quantifier: SignedByQuantifier
-        quantifierParameters: any
-        propertyFactory: NonceLessThanPropertyFactory
+    properties: [
+      {
+        decider: SignedByDecider // Asserts this message is signed by counter-party
+        input: SignedByInput
+        witness: {}
+      },
+      {
+        decider: ForAllSuchThatDecider
+        input: {
+          quantifier: SignedByQuantifier
+          quantifierParameters: any
+          propertyFactory: NonceLessThanPropertyFactory
+        }
       }
-    }
-    rightWitness: any
+    ]
   }
 }
 

--- a/packages/core/src/types/ovm/decider.interface.ts
+++ b/packages/core/src/types/ovm/decider.interface.ts
@@ -8,6 +8,7 @@ export type Proof = ProofItem[]
 export interface Property {
   decider: Decider
   input: {}
+  witness?: any
 }
 
 export type PropertyFactory = (input: any) => Property
@@ -28,11 +29,11 @@ export interface Decision {
  * on the provided input according to the logic of the specific implementation.
  *
  * For example: A PreimageExistsDecider would be able to make decisions on whether
- * or not the provided witness, when hashed, results in the provided input.
+ * or not a hash preimage has been stored in its database.
  */
 export interface Decider {
   /**
-   * Makes a Decision on the provided input, given the provided witness.
+   * Makes a Decision on the provided input.
    *
    * If this Decider is capable of caching and the noCache flag is not set,
    * it will first check to see if a decision has already been made on this input.
@@ -40,10 +41,9 @@ export interface Decider {
    * it will make the Decision, if possible, and overwrite the cache.
    *
    * @param input The input on which a decision is being made
-   * @param witness [optional] The evidence for the decision if not relying on cached decisions
    * @param noCache [optional] Flag set when caching should not be used.
    * @returns the Decision that was made if one was possible
    * @throws CannotDecideError if it cannot decide.
    */
-  decide(input: any, witness?: any, noCache?: boolean): Promise<Decision>
+  decide(input: any, noCache?: boolean): Promise<Decision>
 }

--- a/packages/core/test/app/ovm/deciders/and-decider.spec.ts
+++ b/packages/core/test/app/ovm/deciders/and-decider.spec.ts
@@ -26,16 +26,16 @@ describe('AndDecider', () => {
   describe('decide', () => {
     it('should return true with two true decisions', async () => {
       const andInput: AndDeciderInput = {
-        left: {
-          decider: trueDecider,
-          input: leftInput,
-        },
-        leftWitness,
-        right: {
-          decider: trueDecider,
-          input: rightInput,
-        },
-        rightWitness,
+        properties: [
+          {
+            decider: trueDecider,
+            input: leftInput,
+          },
+          {
+            decider: trueDecider,
+            input: rightInput,
+          },
+        ],
       }
 
       const decision: Decision = await decider.decide(andInput)
@@ -48,23 +48,20 @@ describe('AndDecider', () => {
 
       decision.justification[1].implication.input.should.eq(leftInput)
       decision.justification[2].implication.input.should.eq(rightInput)
-
-      decision.justification[1].implicationWitness.should.eq(leftWitness)
-      decision.justification[2].implicationWitness.should.eq(rightWitness)
     })
 
     it('should return false with left false', async () => {
       const andInput: AndDeciderInput = {
-        left: {
-          decider: falseDecider,
-          input: leftInput,
-        },
-        leftWitness,
-        right: {
-          decider: trueDecider,
-          input: rightInput,
-        },
-        rightWitness,
+        properties: [
+          {
+            decider: falseDecider,
+            input: leftInput,
+          },
+          {
+            decider: trueDecider,
+            input: rightInput,
+          },
+        ],
       }
 
       const decision: Decision = await decider.decide(andInput)
@@ -75,21 +72,20 @@ describe('AndDecider', () => {
       decision.justification[1].implication.decider.should.eq(falseDecider)
 
       decision.justification[1].implication.input.should.eq(leftInput)
-      decision.justification[1].implicationWitness.should.eq(leftWitness)
     })
 
     it('should return false with right false', async () => {
       const andInput: AndDeciderInput = {
-        left: {
-          decider: trueDecider,
-          input: leftInput,
-        },
-        leftWitness,
-        right: {
-          decider: falseDecider,
-          input: rightInput,
-        },
-        rightWitness,
+        properties: [
+          {
+            decider: trueDecider,
+            input: leftInput,
+          },
+          {
+            decider: falseDecider,
+            input: rightInput,
+          },
+        ],
       }
 
       const decision: Decision = await decider.decide(andInput, undefined)
@@ -100,21 +96,20 @@ describe('AndDecider', () => {
       decision.justification[1].implication.decider.should.eq(falseDecider)
 
       decision.justification[1].implication.input.should.eq(rightInput)
-      decision.justification[1].implicationWitness.should.eq(rightWitness)
     })
 
     it('should return false with both false', async () => {
       const andInput: AndDeciderInput = {
-        left: {
-          decider: falseDecider,
-          input: leftInput,
-        },
-        leftWitness,
-        right: {
-          decider: falseDecider,
-          input: rightInput,
-        },
-        rightWitness,
+        properties: [
+          {
+            decider: falseDecider,
+            input: leftInput,
+          },
+          {
+            decider: falseDecider,
+            input: rightInput,
+          },
+        ],
       }
 
       const decision: Decision = await decider.decide(andInput)
@@ -125,21 +120,20 @@ describe('AndDecider', () => {
       decision.justification[1].implication.decider.should.eq(falseDecider)
 
       decision.justification[1].implication.input.should.eq(leftInput)
-      decision.justification[1].implicationWitness.should.eq(leftWitness)
     })
 
     it('should throw when left cannot decide', async () => {
       const andInput: AndDeciderInput = {
-        left: {
-          decider: cannotDecideDecider,
-          input: leftInput,
-        },
-        leftWitness,
-        right: {
-          decider: trueDecider,
-          input: rightInput,
-        },
-        rightWitness,
+        properties: [
+          {
+            decider: cannotDecideDecider,
+            input: leftInput,
+          },
+          {
+            decider: trueDecider,
+            input: rightInput,
+          },
+        ],
       }
 
       try {
@@ -154,16 +148,16 @@ describe('AndDecider', () => {
 
     it('should throw when right cannot decide', async () => {
       const andInput: AndDeciderInput = {
-        left: {
-          decider: trueDecider,
-          input: leftInput,
-        },
-        leftWitness,
-        right: {
-          decider: cannotDecideDecider,
-          input: rightInput,
-        },
-        rightWitness,
+        properties: [
+          {
+            decider: trueDecider,
+            input: leftInput,
+          },
+          {
+            decider: cannotDecideDecider,
+            input: rightInput,
+          },
+        ],
       }
 
       try {
@@ -178,16 +172,16 @@ describe('AndDecider', () => {
 
     it('should throw when both cannot decide', async () => {
       const andInput: AndDeciderInput = {
-        left: {
-          decider: cannotDecideDecider,
-          input: leftInput,
-        },
-        leftWitness,
-        right: {
-          decider: cannotDecideDecider,
-          input: rightInput,
-        },
-        rightWitness,
+        properties: [
+          {
+            decider: cannotDecideDecider,
+            input: leftInput,
+          },
+          {
+            decider: cannotDecideDecider,
+            input: rightInput,
+          },
+        ],
       }
 
       try {

--- a/packages/core/test/app/ovm/deciders/for-all-such-that-decider.spec.ts
+++ b/packages/core/test/app/ovm/deciders/for-all-such-that-decider.spec.ts
@@ -48,8 +48,6 @@ const getPropertyFactoryThatReturns = (
   }
 }
 
-const undefinedWitnessFactory = (input: any) => undefined
-
 /*********
  * TESTS *
  *********/
@@ -70,7 +68,6 @@ describe('ForAllSuchThatDecider', () => {
         quantifier: getQuantifierThatReturns([], true),
         quantifierParameters: undefined,
         propertyFactory: getPropertyFactoryThatReturns([]),
-        witnessFactory: undefinedWitnessFactory,
       }
 
       const decision: Decision = await decider.decide(input)
@@ -85,7 +82,6 @@ describe('ForAllSuchThatDecider', () => {
         quantifier: getQuantifierThatReturns([], true),
         quantifierParameters: undefined,
         propertyFactory: getPropertyFactoryThatReturns([]),
-        witnessFactory: undefined,
       }
 
       const decision: Decision = await decider.decide(input)
@@ -102,7 +98,6 @@ describe('ForAllSuchThatDecider', () => {
         propertyFactory: getPropertyFactoryThatReturns([
           { decider: trueDecider, input: undefined },
         ]),
-        witnessFactory: undefinedWitnessFactory,
       }
 
       const decision: Decision = await decider.decide(input)
@@ -122,7 +117,6 @@ describe('ForAllSuchThatDecider', () => {
           { decider: trueDecider, input: undefined },
           { decider: trueDecider, input: undefined },
         ]),
-        witnessFactory: undefinedWitnessFactory,
       }
 
       const decision: Decision = await decider.decide(input)
@@ -142,7 +136,6 @@ describe('ForAllSuchThatDecider', () => {
         propertyFactory: getPropertyFactoryThatReturns([
           { decider: falseDecider, input: undefined },
         ]),
-        witnessFactory: undefinedWitnessFactory,
       }
 
       const decision: Decision = await decider.decide(input)
@@ -162,7 +155,6 @@ describe('ForAllSuchThatDecider', () => {
           { decider: falseDecider, input: undefined },
           { decider: trueDecider, input: undefined },
         ]),
-        witnessFactory: undefinedWitnessFactory,
       }
 
       const decision: Decision = await decider.decide(input)
@@ -182,7 +174,6 @@ describe('ForAllSuchThatDecider', () => {
           { decider: cannotDecideDecider, input: undefined },
           { decider: falseDecider, input: undefined },
         ]),
-        witnessFactory: undefinedWitnessFactory,
       }
 
       const decision: Decision = await decider.decide(input)
@@ -200,7 +191,6 @@ describe('ForAllSuchThatDecider', () => {
         propertyFactory: getPropertyFactoryThatReturns([
           { decider: cannotDecideDecider, input: undefined },
         ]),
-        witnessFactory: undefinedWitnessFactory,
       }
 
       try {
@@ -225,7 +215,6 @@ describe('ForAllSuchThatDecider', () => {
           { decider: cannotDecideDecider, input: undefined },
           { decider: cannotDecideDecider, input: undefined },
         ]),
-        witnessFactory: undefinedWitnessFactory,
       }
 
       try {
@@ -250,7 +239,6 @@ describe('ForAllSuchThatDecider', () => {
           { decider: trueDecider, input: undefined },
           { decider: cannotDecideDecider, input: undefined },
         ]),
-        witnessFactory: undefinedWitnessFactory,
       }
 
       try {
@@ -275,7 +263,6 @@ describe('ForAllSuchThatDecider', () => {
           { decider: trueDecider, input: undefined },
           { decider: trueDecider, input: undefined },
         ]),
-        witnessFactory: undefinedWitnessFactory,
       }
 
       try {
@@ -300,7 +287,6 @@ describe('ForAllSuchThatDecider', () => {
           { decider: cannotDecideDecider, input: undefined },
           { decider: trueDecider, input: undefined },
         ]),
-        witnessFactory: undefinedWitnessFactory,
       }
 
       try {
@@ -325,7 +311,6 @@ describe('ForAllSuchThatDecider', () => {
           { decider: cannotDecideDecider, input: undefined },
           { decider: falseDecider, input: undefined },
         ]),
-        witnessFactory: undefinedWitnessFactory,
       }
 
       const decision: Decision = await decider.decide(input)

--- a/packages/core/test/app/ovm/deciders/not-decider.spec.ts
+++ b/packages/core/test/app/ovm/deciders/not-decider.spec.ts
@@ -12,7 +12,6 @@ import * as assert from 'assert'
 describe('NotDecider', () => {
   let decider: NotDecider
   const input: string = 'test'
-  const witness: string = 'witness'
 
   const trueDecider: TrueDecider = new TrueDecider()
   const falseDecider: FalseDecider = new FalseDecider()
@@ -28,7 +27,6 @@ describe('NotDecider', () => {
           decider: falseDecider,
           input,
         },
-        witness,
       }
 
       const decision: Decision = await decider.decide(notInput, undefined)
@@ -39,7 +37,6 @@ describe('NotDecider', () => {
       decision.justification[1].implication.decider.should.eq(falseDecider)
 
       decision.justification[1].implication.input.should.eq(input)
-      decision.justification[1].implicationWitness.should.eq(witness)
     })
 
     it('should return false with true decision', async () => {
@@ -48,7 +45,6 @@ describe('NotDecider', () => {
           decider: trueDecider,
           input,
         },
-        witness,
       }
 
       const decision: Decision = await decider.decide(notInput, undefined)
@@ -59,7 +55,6 @@ describe('NotDecider', () => {
       decision.justification[1].implication.decider.should.eq(trueDecider)
 
       decision.justification[1].implication.input.should.eq(input)
-      decision.justification[1].implicationWitness.should.eq(witness)
     })
 
     it('should throw when cannot decide', async () => {
@@ -68,7 +63,6 @@ describe('NotDecider', () => {
           decider: cannotDecideDecider,
           input,
         },
-        witness,
       }
 
       try {

--- a/packages/core/test/app/ovm/deciders/utils.ts
+++ b/packages/core/test/app/ovm/deciders/utils.ts
@@ -22,37 +22,25 @@ const getJustification = (
 }
 
 export class TrueDecider implements Decider {
-  public async checkDecision(input: any): Promise<Decision> {
-    return this.decide(input, undefined)
-  }
-
-  public async decide(input: any, witness: any): Promise<Decision> {
+  public async decide(input: any): Promise<Decision> {
     return {
       outcome: true,
-      justification: getJustification(this, input, witness),
+      justification: getJustification(this, input, true),
     }
   }
 }
 
 export class FalseDecider implements Decider {
-  public async checkDecision(input: any): Promise<Decision> {
-    return this.decide(input, undefined)
-  }
-
-  public async decide(input: any, witness: any): Promise<Decision> {
+  public async decide(input: any): Promise<Decision> {
     return {
       outcome: false,
-      justification: getJustification(this, input, witness),
+      justification: getJustification(this, input, true),
     }
   }
 }
 
 export class CannotDecideDecider implements Decider {
-  public async checkDecision(input: any): Promise<Decision> {
-    return this.decide(input, undefined)
-  }
-
-  public async decide(input: any, witness: any): Promise<Decision> {
+  public async decide(input: any): Promise<Decision> {
     throw new CannotDecideError('Cannot decide!')
   }
 }

--- a/packages/core/test/app/ovm/examples/simple-state-channel.spec.ts
+++ b/packages/core/test/app/ovm/examples/simple-state-channel.spec.ts
@@ -763,45 +763,46 @@ describe('State Channel Tests', () => {
           decider: AndDecider.instance(),
           input: {
             // Claim that B has signed the message to be exited (this will evaluate to true)
-            left: {
-              decider: bSignedByDecider,
-              input: {
-                message: messageToBuffer(
-                  mostRecentMessage.message,
-                  stateChannelMessageToString
-                ),
-                publicKey: bAddress,
-              },
-            },
-            leftWitness: {
-              signature: mostRecentMessage.signatures[bAddress.toString()],
-            },
-            // Claim that A has not signed any message with nonce higher than the previous message (wrong)
-            right: {
-              decider: ForAllSuchThatDecider.instance(),
-              input: {
-                quantifier: bSignedByQuantifier,
-                quantifierParameters: {
-                  address: aAddress,
-                  channelID: mostRecentMessage.message.channelID,
+            properties: [
+              {
+                decider: bSignedByDecider,
+                input: {
+                  message: messageToBuffer(
+                    mostRecentMessage.message,
+                    stateChannelMessageToString
+                  ),
+                  publicKey: bAddress,
                 },
-                propertyFactory: (message: Buffer) => {
-                  return {
-                    decider: MessageNonceLessThanDecider.instance(),
-                    input: {
-                      messageWithNonce: deserializeBuffer(
-                        message,
-                        deserializeMessage,
-                        stateChannelMessageDeserializer
-                      ),
-                      // This will be disputed because mostRecentMessage has been signed by A
-                      lessThanThis: mostRecentMessage.message.nonce,
-                    },
-                  }
+                witness: {
+                  signature: mostRecentMessage.signatures[bAddress.toString()],
                 },
               },
-            },
-            rightWitness: undefined,
+              // Claim that A has not signed any message with nonce higher than the previous message (wrong)
+              {
+                decider: ForAllSuchThatDecider.instance(),
+                input: {
+                  quantifier: bSignedByQuantifier,
+                  quantifierParameters: {
+                    address: aAddress,
+                    channelID: mostRecentMessage.message.channelID,
+                  },
+                  propertyFactory: (message: Buffer) => {
+                    return {
+                      decider: MessageNonceLessThanDecider.instance(),
+                      input: {
+                        messageWithNonce: deserializeBuffer(
+                          message,
+                          deserializeMessage,
+                          stateChannelMessageDeserializer
+                        ),
+                        // This will be disputed because mostRecentMessage has been signed by A
+                        lessThanThis: mostRecentMessage.message.nonce,
+                      },
+                    }
+                  },
+                },
+              },
+            ],
           },
         }
 
@@ -864,46 +865,47 @@ describe('State Channel Tests', () => {
         const refutableClaim: StateChannelExitClaim = {
           decider: AndDecider.instance(),
           input: {
-            // Claim that A has signed the message to be exited (this will evaluate to true)
-            left: {
-              decider: aSignedByDecider,
-              input: {
-                message: messageToBuffer(
-                  mostRecentMessage.message,
-                  stateChannelMessageToString
-                ),
-                publicKey: aAddress,
-              },
-            },
-            leftWitness: {
-              signature: mostRecentMessage.signatures[aAddress.toString()],
-            },
-            // Claim that B has not signed any message with nonce higher than the previous message (wrong)
-            right: {
-              decider: ForAllSuchThatDecider.instance(),
-              input: {
-                quantifier: aSignedByQuantifier,
-                quantifierParameters: {
-                  address: bAddress,
-                  channelID: mostRecentMessage.message.channelID,
+            // Claim that B has signed the message to be exited (this will evaluate to true)
+            properties: [
+              {
+                decider: aSignedByDecider,
+                input: {
+                  message: messageToBuffer(
+                    mostRecentMessage.message,
+                    stateChannelMessageToString
+                  ),
+                  publicKey: aAddress,
                 },
-                propertyFactory: (message: Buffer) => {
-                  return {
-                    decider: MessageNonceLessThanDecider.instance(),
-                    input: {
-                      messageWithNonce: deserializeBuffer(
-                        message,
-                        deserializeMessage,
-                        stateChannelMessageDeserializer
-                      ),
-                      // This will be disputed because mostRecentMessage has been signed by B
-                      lessThanThis: mostRecentMessage.message.nonce,
-                    },
-                  }
+                witness: {
+                  signature: mostRecentMessage.signatures[aAddress.toString()],
                 },
               },
-            },
-            rightWitness: undefined,
+              // Claim that A has not signed any message with nonce higher than the previous message (wrong)
+              {
+                decider: ForAllSuchThatDecider.instance(),
+                input: {
+                  quantifier: aSignedByQuantifier,
+                  quantifierParameters: {
+                    address: bAddress,
+                    channelID: mostRecentMessage.message.channelID,
+                  },
+                  propertyFactory: (message: Buffer) => {
+                    return {
+                      decider: MessageNonceLessThanDecider.instance(),
+                      input: {
+                        messageWithNonce: deserializeBuffer(
+                          message,
+                          deserializeMessage,
+                          stateChannelMessageDeserializer
+                        ),
+                        // This will be disputed because mostRecentMessage has been signed by A
+                        lessThanThis: mostRecentMessage.message.nonce,
+                      },
+                    }
+                  },
+                },
+              },
+            ],
           },
         }
 


### PR DESCRIPTION
## Description
Removes deprecated `witness` parameter for Deciders. Also makes AndDecider accept more than 2 inputs.

## Questions
- Any reason we can think of as to why we would need `witness`

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Plasma Group Contributing Guide and Code of Conduct](https://github.com/plasma-group/pigi/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
