### PR TITLE
Full signature support/compatibility for contract/client/aggregator

### DIFF
--- a/packages/contracts/contracts/UnipigTransitionEvaluator.sol
+++ b/packages/contracts/contracts/UnipigTransitionEvaluator.sol
@@ -46,13 +46,6 @@ contract UnipigTransitionEvaluator is TransitionEvaluator {
         return outputs;
     }
 
-    function verifyEcdsaSignatureOnHash(bytes memory _signature, bytes32 _hash, address _pubkey) private pure returns(bool) {
-        bytes memory prefixedMessage = abi.encodePacked("\x19Ethereum Signed Message:\n32", _hash);
-        bytes32 digest = keccak256(prefixedMessage);
-        (uint8 v, bytes32 r, bytes32 s) = splitSignature(_signature);
-        return ecrecover(digest, v, r, s) == _pubkey;
-    }
-
     /**
      * Return the tx type inferred by the length of bytes
      */
@@ -348,14 +341,11 @@ contract UnipigTransitionEvaluator is TransitionEvaluator {
 
         return (v, r, s);
     }
-    // recovers a signer for a message (technically, an ethereum-compliant signature on the HASH of the message, which our DefaultSignatureProvider performs.)
-    function recoverSigner(bytes memory message, bytes memory sig) public pure returns (address)
-    {
-        bytes32 messageHash = keccak256(message);
-        bytes memory prefixedMessage = abi.encodePacked("\x19Ethereum Signed Message:\n32", messageHash);
+    // verifies a signature on a 32 byte value--note this means we must be signing/verifying the hash of our transactions, not the encodings themselves--luckily, DefaultSignatureProvider now does this.
+    function verifyEcdsaSignatureOnHash(bytes memory _signature, bytes32 _hash, address _pubkey) private pure returns(bool) {
+        bytes memory prefixedMessage = abi.encodePacked("\x19Ethereum Signed Message:\n32", _hash);
         bytes32 digest = keccak256(prefixedMessage);
-        (uint8 v, bytes32 r, bytes32 s) = splitSignature(sig);
-
-        return ecrecover(digest, v, r, s);
+        (uint8 v, bytes32 r, bytes32 s) = splitSignature(_signature);
+        return ecrecover(digest, v, r, s) == _pubkey;
     }
 }

--- a/packages/contracts/contracts/UnipigTransitionEvaluator.sol
+++ b/packages/contracts/contracts/UnipigTransitionEvaluator.sol
@@ -46,8 +46,11 @@ contract UnipigTransitionEvaluator is TransitionEvaluator {
         return outputs;
     }
 
-    function verifyEcdsaSignature(bytes memory _signature, bytes32 _hash, address _pubkey) private pure returns(bool) {
-        return true;
+    function verifyEcdsaSignatureOnHash(bytes memory _signature, bytes32 _hash, address _pubkey) private pure returns(bool) {
+        bytes memory prefixedMessage = abi.encodePacked("\x19Ethereum Signed Message:\n32", _hash);
+        bytes32 digest = keccak256(prefixedMessage);
+        (uint8 v, bytes32 r, bytes32 s) = splitSignature(_signature);
+        return ecrecover(digest, v, r, s) == _pubkey;
     }
 
     /**
@@ -157,7 +160,7 @@ contract UnipigTransitionEvaluator is TransitionEvaluator {
         dt.TransferTx memory transferTx = dt.TransferTx(sender, recipient, _transition.tokenType, _transition.amount);
 
         // Next check to see if the signature is valid
-        require(verifyEcdsaSignature(_transition.signature, getTransferTxHash(transferTx), sender), "Transfer signature is invalid!");
+        require(verifyEcdsaSignatureOnHash(_transition.signature, getTransferTxHash(transferTx), sender), "Transfer signature is invalid!");
         // Also make sure we're not sending to Unipig
         require(_storageSlots[1].slotIndex != UNISWAP_SLOT_INDEX, "Transfer cannot be made to Unipig!");
 
@@ -198,7 +201,7 @@ contract UnipigTransitionEvaluator is TransitionEvaluator {
         );
 
         // Make sure that the provided storage slots are corrent
-        require(verifyEcdsaSignature(_transition.signature, getSwapTxHash(swapTx), sender), "Swap signature is invalid!");
+        require(verifyEcdsaSignatureOnHash(_transition.signature, getSwapTxHash(swapTx), sender), "Swap signature is invalid!");
         require(_storageSlots[1].slotIndex == UNISWAP_SLOT_INDEX && recipient == UNISWAP_ADDRESS, "Swap tx must be swapping with Unipig!");
 
         // Create an array to store our output storage slots
@@ -328,4 +331,31 @@ contract UnipigTransitionEvaluator is TransitionEvaluator {
          );
          return transition;
      }
+
+    // splits a signature string into v, r, s
+    function splitSignature(bytes memory sig) internal pure returns (uint8 v, bytes32 r, bytes32 s)
+    {
+        require(sig.length == 65, 'invalid signature length.');
+
+        assembly {
+            // first 32 bytes, after the length prefix.
+            r := mload(add(sig, 32))
+            // second 32 bytes.
+            s := mload(add(sig, 64))
+            // final byte (first byte of the next 32 bytes).
+            v := byte(0, mload(add(sig, 96)))
+        }
+
+        return (v, r, s);
+    }
+    // recovers a signer for a message (technically, an ethereum-compliant signature on the HASH of the message, which our DefaultSignatureProvider performs.)
+    function recoverSigner(bytes memory message, bytes memory sig) public pure returns (address)
+    {
+        bytes32 messageHash = keccak256(message);
+        bytes memory prefixedMessage = abi.encodePacked("\x19Ethereum Signed Message:\n32", messageHash);
+        bytes32 digest = keccak256(prefixedMessage);
+        (uint8 v, bytes32 r, bytes32 s) = splitSignature(sig);
+
+        return ecrecover(digest, v, r, s);
+    }
 }

--- a/packages/contracts/test/rollup-chain-manager/RollupChain.spec.ts
+++ b/packages/contracts/test/rollup-chain-manager/RollupChain.spec.ts
@@ -36,7 +36,7 @@ import {
   BigNumber,
   BaseDB,
   SparseMerkleTreeImpl,
-  DefaultSignatureProvider
+  DefaultSignatureProvider,
 } from '@pigi/core'
 import {
   SwapTransition,

--- a/packages/contracts/test/rollup-chain-manager/RollupChain.spec.ts
+++ b/packages/contracts/test/rollup-chain-manager/RollupChain.spec.ts
@@ -36,12 +36,15 @@ import {
   BigNumber,
   BaseDB,
   SparseMerkleTreeImpl,
+  DefaultSignatureProvider
 } from '@pigi/core'
 import {
   SwapTransition,
   TransferTransition,
   CreateAndTransferTransition,
+  Transfer,
   abiEncodeTransition,
+  abiEncodeTransaction,
   State,
   abiEncodeState,
   DefaultRollupBlock,
@@ -357,9 +360,11 @@ describe('RollupChain', () => {
    */
   describe('proveTransitionInvalid() ', async () => {
     it('should throw if attempting to prove invalid a valid transition', async () => {
+      const signatureProvider = new DefaultSignatureProvider()
       const sentAmount = 5
+      const tokenType = 0
       const storageSlots = [5, 10]
-      const pubkeys = [getAddress('11'), getAddress('22')]
+      const pubkeys = [await signatureProvider.getAddress(), getAddress('22')]
       const balances = [{ '0': 10, '1': 20 }, { '0': 100, '1': 200 }]
       // Post balances after a send of 5 uni
       const postBalances = [
@@ -426,6 +431,16 @@ describe('RollupChain', () => {
       // Store the post state root
       const postStateRoot = bufToHexString(await stateTree.getRootHash())
 
+      // create a valid transfer transaction and signature (this will be the second transfer transition--the one being checked) to pass the unipig transition verifier.
+      const transactionForSecondTransfer: Transfer = {
+        sender: pubkeys[0],
+        recipient: pubkeys[1],
+        tokenType,
+        amount: sentAmount,
+      }
+      const signature = await signatureProvider.sign(
+        abiEncodeTransaction(transactionForSecondTransfer)
+      )
       // 3) Create transfer transitions
       //
       const transferTransitions: TransferTransition[] = [
@@ -433,7 +448,7 @@ describe('RollupChain', () => {
           stateRoot: preStateRoot,
           senderSlotIndex: storageSlots[0],
           recipientSlotIndex: storageSlots[1],
-          tokenType: 0,
+          tokenType,
           amount: 1,
           signature: getSignature('42'),
         },
@@ -441,9 +456,9 @@ describe('RollupChain', () => {
           stateRoot: postStateRoot,
           senderSlotIndex: storageSlots[0],
           recipientSlotIndex: storageSlots[1],
-          tokenType: 0,
+          tokenType,
           amount: sentAmount,
-          signature: getSignature('42'),
+          signature,
         },
       ]
       // Encode them!

--- a/packages/contracts/test/transition-evaluators/unipig-transition-verifier.spec.ts
+++ b/packages/contracts/test/transition-evaluators/unipig-transition-verifier.spec.ts
@@ -58,7 +58,7 @@ const log = debug('test:info:unipig-transition-evaluator')
 import * as UnipigTransitionEvaluator from '../../build/UnipigTransitionEvaluator.json'
 
 /* Begin tests */
-describe.only('UnipigTransitionEvaluator', () => {
+describe('UnipigTransitionEvaluator', () => {
   const provider = createMockProvider()
   const [wallet1] = getWallets(provider)
   let unipigEvaluator
@@ -81,17 +81,6 @@ describe.only('UnipigTransitionEvaluator', () => {
         gasLimit: 6700000,
       }
     )
-  })
-  /*
-   * Test Signature Utils
-   */
-  describe('recoverSigner()', async () => {
-    it('should recover the correct signer', async () => {
-      const messageToSign: string = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-      const signature: string = await signatureProvider.sign(messageToSign)
-      const contractRecoveredSigner = await unipigEvaluator.recoverSigner(messageToSign, signature)
-      contractRecoveredSigner.should.equal(await signatureProvider.getAddress())
-    })
   })
   /*
    * Test inferTransitionType()
@@ -268,7 +257,7 @@ describe.only('UnipigTransitionEvaluator', () => {
       const sentAmount = 5
       const initialBalances = [1000, 1000]
       const senderSlotIndex = 50
-      const senderAddress = await signatureProvider.getAddress() as Address
+      const senderAddress = (await signatureProvider.getAddress()) as Address
       const recipientAddress = getAddress('38')
       const recipientSlotIndex = 100
       const tokenType = 0
@@ -293,12 +282,12 @@ describe.only('UnipigTransitionEvaluator', () => {
         sender: senderAddress,
         recipient: recipientAddress,
         tokenType,
-        amount: sentAmount
+        amount: sentAmount,
       }
       const signature = await signatureProvider.sign(
         abiEncodeTransaction(transaction)
       )
-      // Create the transition  
+      // Create the transition
       const transition: TransferTransition = {
         stateRoot: getStateRoot('ab'),
         senderSlotIndex,
@@ -446,7 +435,7 @@ describe.only('UnipigTransitionEvaluator', () => {
         sender: senderAddress,
         recipient: recipientAddress,
         tokenType,
-        amount: sentAmount
+        amount: sentAmount,
       }
       const signature = await signatureProvider.sign(
         abiEncodeTransaction(transaction)
@@ -571,7 +560,7 @@ describe.only('UnipigTransitionEvaluator', () => {
         inputAmount,
         minOutputAmount,
         timeout,
-        signature: signature,
+        signature,
       }
       // Attempt to apply the transaction
       const res = await unipigEvaluator.applySwapTransition(swap, [
@@ -814,7 +803,7 @@ describe.only('UnipigTransitionEvaluator', () => {
         sender: senderAddress,
         recipient: recipientAddress,
         tokenType,
-        amount: sentAmount
+        amount: sentAmount,
       }
       const signature = await signatureProvider.sign(
         abiEncodeTransaction(transaction)
@@ -869,7 +858,7 @@ describe.only('UnipigTransitionEvaluator', () => {
         sender: senderAddress,
         recipient: recipientAddress,
         tokenType,
-        amount: sentAmount
+        amount: sentAmount,
       }
       const signature = await signatureProvider.sign(
         abiEncodeTransaction(transaction)

--- a/packages/core/src/app/keystore/signatures.ts
+++ b/packages/core/src/app/keystore/signatures.ts
@@ -1,5 +1,6 @@
 import { SignatureProvider, SignatureVerifier } from '../../types/keystore'
 import { ethers } from 'ethers'
+import { hexStrToBuf } from '../../../'
 
 export class DefaultSignatureVerifier implements SignatureVerifier {
   private static _instance: SignatureVerifier
@@ -12,7 +13,9 @@ export class DefaultSignatureVerifier implements SignatureVerifier {
   }
 
   public verifyMessage(message: string, signature: string): string {
-    return ethers.utils.verifyMessage(message, signature)
+    const messageAsBuf: Buffer = hexStrToBuf(message)
+    const messageHash: string = ethers.utils.keccak256(messageAsBuf)
+    return ethers.utils.verifyMessage(hexStrToBuf(messageHash), signature)
   }
 }
 
@@ -22,7 +25,9 @@ export class DefaultSignatureProvider implements SignatureProvider {
   ) {}
 
   public async sign(message: string): Promise<string> {
-    return this.wallet.signMessage(message)
+    const messageAsBuf: Buffer = hexStrToBuf(message)
+    const messageHash: string = ethers.utils.keccak256(messageAsBuf)
+    return this.wallet.signMessage(hexStrToBuf(messageHash))
   }
 
   public async getAddress(): Promise<string> {

--- a/packages/core/src/app/keystore/signatures.ts
+++ b/packages/core/src/app/keystore/signatures.ts
@@ -13,6 +13,7 @@ export class DefaultSignatureVerifier implements SignatureVerifier {
   }
 
   public verifyMessage(message: string, signature: string): string {
+    // NOTE: we are hashing the message to sign to make the contracts easier (fixed prefix instead of legth prefix).   This should be changed once we support the alternative.
     const messageAsBuf: Buffer = hexStrToBuf(message)
     const messageHash: string = ethers.utils.keccak256(messageAsBuf)
     return ethers.utils.verifyMessage(hexStrToBuf(messageHash), signature)
@@ -25,6 +26,7 @@ export class DefaultSignatureProvider implements SignatureProvider {
   ) {}
 
   public async sign(message: string): Promise<string> {
+    // NOTE: we are hashing the message to sign to make the contracts easier (fixed prefix instead of legth prefix).   This should be changed once we support the alternative.
     const messageAsBuf: Buffer = hexStrToBuf(message)
     const messageHash: string = ethers.utils.keccak256(messageAsBuf)
     return this.wallet.signMessage(hexStrToBuf(messageHash))

--- a/packages/core/src/app/serialization/serializers.ts
+++ b/packages/core/src/app/serialization/serializers.ts
@@ -1,5 +1,6 @@
 import { AddressBalance, StateChannelMessage } from './examples'
 import { BigNumber, Message } from '../../types'
+import { hexStrToBuf } from '../utils'
 
 /**
  * Serializes the provided object to its canonical string representation.
@@ -20,6 +21,31 @@ export const serializeObject = (obj: {}): string => {
  */
 export const deserializeObject = (obj: string): {} => {
   return JSON.parse(obj)
+}
+
+
+/**
+ * Serializes the provided object to its canonical hex string representation.
+ *
+ * @param obj The object to serialize.
+ * @returns The serialized object as a string.
+ */
+export const serializeObjectAsHexString = (obj: {}): string => {
+  const stringified: string = JSON.stringify(obj)
+  const asHexString = '0x' + Buffer.from(stringified, 'utf-8').toString('hex')
+  return asHexString
+}
+
+/**
+ * Deserializes the provided hex string into its object representation.
+ * This assumes the string was serialized using the associated serializer.
+ *
+ * @param obj The string to deserialize.
+ * @returns The deserialized object.
+ */
+export const deserializeObjectAsHexString = (obj: string): {} => {
+  const asBuffer = hexStrToBuf(obj).slice(2)
+  return JSON.parse(asBuffer.toString('utf-8'))
 }
 
 /**

--- a/packages/core/src/app/serialization/serializers.ts
+++ b/packages/core/src/app/serialization/serializers.ts
@@ -23,7 +23,6 @@ export const deserializeObject = (obj: string): {} => {
   return JSON.parse(obj)
 }
 
-
 /**
  * Serializes the provided object to its canonical hex string representation.
  *

--- a/packages/core/src/app/serialization/serializers.ts
+++ b/packages/core/src/app/serialization/serializers.ts
@@ -1,6 +1,6 @@
 import { AddressBalance, StateChannelMessage } from './examples'
 import { BigNumber, Message } from '../../types'
-import { hexStrToBuf } from '../utils'
+import { hexStrToBuf, remove0x } from '../utils'
 
 /**
  * Serializes the provided object to its canonical string representation.
@@ -43,7 +43,7 @@ export const serializeObjectAsHexString = (obj: {}): string => {
  * @returns The deserialized object.
  */
 export const deserializeObjectAsHexString = (obj: string): {} => {
-  const asBuffer = hexStrToBuf(obj).slice(2)
+  const asBuffer = hexStrToBuf(remove0x(obj))
   return JSON.parse(asBuffer.toString('utf-8'))
 }
 

--- a/packages/core/src/app/serialization/serializers.ts
+++ b/packages/core/src/app/serialization/serializers.ts
@@ -31,7 +31,7 @@ export const deserializeObject = (obj: string): {} => {
  */
 export const serializeObjectAsHexString = (obj: {}): string => {
   const stringified: string = JSON.stringify(obj)
-  const asHexString = '0x' + Buffer.from(stringified, 'utf-8').toString('hex')
+  const asHexString = '0x' + Buffer.from(stringified).toString('hex')
   return asHexString
 }
 
@@ -44,7 +44,7 @@ export const serializeObjectAsHexString = (obj: {}): string => {
  */
 export const deserializeObjectAsHexString = (obj: string): {} => {
   const asBuffer = hexStrToBuf(remove0x(obj))
-  return JSON.parse(asBuffer.toString('utf-8'))
+  return JSON.parse(asBuffer.toString())
 }
 
 /**

--- a/packages/wallet/src/aggregator/rollup-aggregator.ts
+++ b/packages/wallet/src/aggregator/rollup-aggregator.ts
@@ -5,6 +5,7 @@ import {
   SignatureVerifier,
   DefaultSignatureVerifier,
   serializeObject,
+  serializeObjectAsHexString,
   DB,
   getLogger,
   hexStrToBuf,
@@ -274,7 +275,7 @@ export class RollupAggregator
         throw Error('Cannot handle non-Faucet Request in faucet endpoint')
       }
       const messageSigner: Address = this.signatureVerifier.verifyMessage(
-        serializeObject(signedTransaction.transaction),
+        serializeObjectAsHexString(signedTransaction.transaction),
         signedTransaction.signature
       )
       if (messageSigner !== signedTransaction.transaction.sender) {

--- a/packages/wallet/src/rollup-client.ts
+++ b/packages/wallet/src/rollup-client.ts
@@ -93,7 +93,9 @@ export class RollupClient {
     transaction: RollupTransaction,
     signatureProvider: SignatureProvider
   ): Promise<SignedStateReceipt> {
-    const signature = await signatureProvider.sign(serializeObjectAsHexString(transaction))
+    const signature = await signatureProvider.sign(
+      serializeObjectAsHexString(transaction)
+    )
     const receipt: SignedStateReceipt = await this.rpcClient.handle<
       SignedStateReceipt
     >(AGGREGATOR_API.requestFaucetFunds, {

--- a/packages/wallet/src/rollup-client.ts
+++ b/packages/wallet/src/rollup-client.ts
@@ -5,6 +5,7 @@ import {
   KeyValueStore,
   RpcClient,
   serializeObject,
+  serializeObjectAsHexString,
   SignatureProvider,
   SignatureVerifier,
 } from '@pigi/core'
@@ -92,7 +93,7 @@ export class RollupClient {
     transaction: RollupTransaction,
     signatureProvider: SignatureProvider
   ): Promise<SignedStateReceipt> {
-    const signature = await signatureProvider.sign(serializeObject(transaction))
+    const signature = await signatureProvider.sign(serializeObjectAsHexString(transaction))
     const receipt: SignedStateReceipt = await this.rpcClient.handle<
       SignedStateReceipt
     >(AGGREGATOR_API.requestFaucetFunds, {

--- a/packages/wallet/test/rollup-aggregator.spec.ts
+++ b/packages/wallet/test/rollup-aggregator.spec.ts
@@ -109,7 +109,8 @@ describe('RollupAggregator', () => {
         amount,
       }
       const signature = await senderWallet.signMessage(
-        abiEncodeTransaction(transaction)
+        // right now, we are actually signing the hash of our messages to make the contract work.  (See DefaultSignatureProvider)
+        hexStrToBuf(ethers.utils.keccak256(abiEncodeTransaction(transaction)))
       )
       const tx = {
         signature,
@@ -163,7 +164,8 @@ describe('RollupAggregator', () => {
         amount,
       }
       const signature = await newWallet.signMessage(
-        serializeObject(transaction)
+        // right now, we are actually signing the hash of our messages to make the contract work.  (See DefaultSignatureProvider)
+        hexStrToBuf(ethers.utils.keccak256(serializeObject(transaction)))
       )
       const signedRequest: SignedTransaction = {
         signature,

--- a/packages/wallet/test/rollup-aggregator.spec.ts
+++ b/packages/wallet/test/rollup-aggregator.spec.ts
@@ -166,7 +166,9 @@ describe('RollupAggregator', () => {
       }
       const signature = await newWallet.signMessage(
         // right now, we are actually signing the hash of our messages to make the contract work.  (See DefaultSignatureProvider)
-        hexStrToBuf(ethers.utils.keccak256(serializeObjectAsHexString(transaction)))
+        hexStrToBuf(
+          ethers.utils.keccak256(serializeObjectAsHexString(transaction))
+        )
       )
       const signedRequest: SignedTransaction = {
         signature,

--- a/packages/wallet/test/rollup-aggregator.spec.ts
+++ b/packages/wallet/test/rollup-aggregator.spec.ts
@@ -13,6 +13,7 @@ import {
   keccak256,
   newInMemoryDB,
   serializeObject,
+  serializeObjectAsHexString,
   SimpleClient,
   sleep,
   SparseMerkleTree,
@@ -165,7 +166,7 @@ describe('RollupAggregator', () => {
       }
       const signature = await newWallet.signMessage(
         // right now, we are actually signing the hash of our messages to make the contract work.  (See DefaultSignatureProvider)
-        hexStrToBuf(ethers.utils.keccak256(serializeObject(transaction)))
+        hexStrToBuf(ethers.utils.keccak256(serializeObjectAsHexString(transaction)))
       )
       const signedRequest: SignedTransaction = {
         signature,


### PR DESCRIPTION
## Description
Adds sig checking to the contracts, and makes the necessary changes for those to be compatible with the aggregator and client.

Specifically, note that for a few reasons this makes it so that the signatures are actually on hashes of the underlying data.  The ``DefaultSignatureProvider`` and ``DefaultSignatureVerifier`` both do this now, and hopefully nothing will break--all tests pass so I think we're good.

It took me a while to track down an associated bug which stemmed from ethers always signing the ASCII representation of strings, even if they start with ``0x`` like all of ours were.  So, the strings are now converted to buffers before being hashed and signed.  This broke regular signing and hashing for ``serializeObject``s, because this just uses JSON.stringify which is not a hex string, and this was being done for the faucet requests since they never need the ABI treatment.  So, I added a ``serializeObjectAsHexString`` and used that for receipts both client and server side.
## Questions
- 
-
-

## Metadata
### Fixes
- Fixes #
- Fixes #
- Fixes #

### Blockers
- #
- #
- #

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [X] I have read and understood the [Plasma Group Contributing Guide and Code of Conduct](https://github.com/plasma-group/pigi/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
